### PR TITLE
repo-kit: fix crash when running via npx

### DIFF
--- a/.changeset/happy-ghosts-ring.md
+++ b/.changeset/happy-ghosts-ring.md
@@ -1,0 +1,5 @@
+---
+'@twin-digital/repo-kit': patch
+---
+
+fix crash when running via npx

--- a/nodejs/devtools/repo-kit/src/cli/entry-point.ts
+++ b/nodejs/devtools/repo-kit/src/cli/entry-point.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import fs from 'node:fs'
 import path from 'node:path'
 import { Command } from 'commander'


### PR DESCRIPTION
The entry-point script was missing a valid shebang, so the tool could not be invoked.