### PR TITLE
implement slash command support and saving of rolled stats

### DIFF
--- a/.changeset/gentle-olives-cheer.md
+++ b/.changeset/gentle-olives-cheer.md
@@ -1,0 +1,5 @@
+---
+'@twin-digital/codex': minor
+---
+
+add bot support for input command handling

--- a/.changeset/light-chefs-post.md
+++ b/.changeset/light-chefs-post.md
@@ -1,0 +1,5 @@
+---
+'@twin-digital/codex': minor
+---
+
+update stats rolling to be a chat command instead of message-based

--- a/.changeset/smart-jeans-wave.md
+++ b/.changeset/smart-jeans-wave.md
@@ -1,0 +1,5 @@
+---
+'@twin-digital/codex': minor
+---
+
+add persistent stat rolling and replay of existing stats

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "experimentalTernaries": true,
   "jsxSingleQuote": true,
+  "printWidth": 120,
   "semi": false,
   "singleQuote": true
 }

--- a/.repo-kit.yml
+++ b/.repo-kit.yml
@@ -243,10 +243,7 @@ features:
           file: tsconfig.json
           content: |
             {
-              "extends": [
-                "@twin-digital/tsconfig/tsconfig.build.json",
-                "./tsconfig.options.json"
-              ]
+              "extends": ["@twin-digital/tsconfig/tsconfig.build.json", "./tsconfig.options.json"]
             }
       - name: Add scripts and dependencies
         action: json-merge-patch

--- a/nodejs/apps/codex/.env.example
+++ b/nodejs/apps/codex/.env.example
@@ -1,7 +1,14 @@
 # Copy this to .env and fill the values for local development
 # Required environment variables for the Codex bot
-DISCORD_TOKEN=your_discord_bot_token_here
-DISCORD_APP_ID=your_discord_app_id_here
 
-# Optional: override NODE_ENV for dev
-# NODE_ENV=development
+# aws config
+AWS_ACCESS_KEY_ID=<your-access-key-id>
+AWS_REGION=us-east-1
+AWS_SECRET_ACCESS_KEY=<your-access-key-secret>
+
+# codex config
+CODEX_DICE_CHANNEL_ID=<channel-id>
+CODEX_REPOSITORY_BUCKET=<bucket-name>
+CODEX_REPOSITORY_PREFIX=<bucket-prefix, e.g. codex/dev>
+DISCORD_TOKEN=<your-discord-token>
+DISCORD_APP_ID=<your-discord-app-id>

--- a/nodejs/apps/codex/docker-compose.yml
+++ b/nodejs/apps/codex/docker-compose.yml
@@ -4,9 +4,6 @@ services:
       context: ../../../
       dockerfile: nodejs/apps/codex/Dockerfile
       target: runner
-    env_file:
-      - .env
-    working_dir: /app
     develop:
       watch:
         # Sync bin and dist changes, restart container
@@ -19,4 +16,7 @@ services:
         # Rebuild image if package.json changes
         - path: ./package.json
           action: rebuild
+    env_file:
+      - .env
     restart: unless-stopped
+    working_dir: /app

--- a/nodejs/apps/codex/docs/REPOSITORY_COORDINATOR.md
+++ b/nodejs/apps/codex/docs/REPOSITORY_COORDINATOR.md
@@ -1,0 +1,174 @@
+# Repository Coordinator
+
+A unified persistence layer for the Codex bot that stores all entity types in a single S3 JSON document.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│         Application Code                │
+│  (Services, Commands, Behaviors)        │
+└─────────────┬───────────────────────────┘
+              │ Uses typed Repository<T>
+              │
+┌─────────────▼───────────────────────────┐
+│      RepositoryCoordinator              │
+│  - Manages lifecycle (init/flush)       │
+│  - Debounces saves to S3                │
+│  - Creates wrapped repositories         │
+└─────────────┬───────────────────────────┘
+              │
+    ┌─────────┴─────────┐
+    │                   │
+┌───▼────────┐  ┌───────▼────┐
+│MemoryRepo  │  │MemoryRepo  │
+│ (players)  │  │(characters)│
+└───┬────────┘  └───────┬────┘
+    │                   │
+    └─────────┬─────────┘
+              │
+      ┌───────▼──────────┐
+      │  DocumentStore   │
+      │  (S3 JSON blob)  │
+      └──────────────────┘
+```
+
+## Key Features
+
+- **Single JSON document**: All entity types stored together in one S3 object
+- **Transparent**: Application code uses standard `Repository<T>` interface
+- **Debounced saves**: Changes batched to minimize S3 writes (default: 2s)
+- **Type-safe**: Full TypeScript support for entity types
+- **Graceful shutdown**: `flush()` ensures all changes persisted before exit
+
+## Usage
+
+### 1. Define your entity types
+
+```typescript
+interface Player extends Record<string, unknown> {
+  id: string
+  name: string
+  level: number
+}
+```
+
+**Important**: All entities must:
+
+- Extend `Record<string, unknown>`
+- Have an `id: string` property (used as the key in the document)
+
+### 2. Initialize the coordinator
+
+```typescript
+const coordinator = new RepositoryCoordinator({
+  bucket: 'my-s3-bucket',
+  documentId: 'bot-data.json',
+  saveDebounceMs: 2000,
+  log: consoleLogger,
+})
+
+await coordinator.init() // Loads existing data from S3
+```
+
+### 3. Get typed repositories
+
+```typescript
+const playerRepo = coordinator.getRepository<Player>('players')
+const characterRepo = coordinator.getRepository<Character>('characters')
+```
+
+The first argument (`'players'`, `'characters'`) becomes the top-level key in the JSON document.
+
+### 4. Use standard Repository operations
+
+```typescript
+// Create/update
+await playerRepo.upsert('player1', {
+  id: 'player1',
+  name: 'Alice',
+  level: 5,
+})
+
+// Read
+const player = await playerRepo.get('player1')
+
+// List all
+const allPlayers = await playerRepo.list()
+
+// Delete
+await playerRepo.delete('player1')
+```
+
+### 5. Flush before shutdown
+
+```typescript
+process.on('SIGTERM', async () => {
+  await coordinator.flush()
+  process.exit(0)
+})
+```
+
+## S3 Document Structure
+
+The coordinator stores data in this format:
+
+```json
+{
+  "players": {
+    "player1": {
+      "id": "player1",
+      "name": "Alice",
+      "level": 5
+    },
+    "player2": { ... }
+  },
+  "characters": {
+    "char1": {
+      "id": "char1",
+      "playerId": "player1",
+      "class": "Wizard",
+      "stats": { "strength": 8, ... }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+Required for bot startup:
+
+- `CODEX_S3_BUCKET` - S3 bucket name
+- `CODEX_S3_DOCUMENT_ID` - JSON filename (default: `codex-data.json`)
+- `AWS_REGION` - AWS region for S3 client
+
+## Implementation Notes
+
+### Why debounced saves?
+
+Rapid updates (e.g., multiple stat rolls in quick succession) would cause many S3 writes. Debouncing batches these into a single write, reducing costs and avoiding rate limits.
+
+### When are changes saved?
+
+- Automatically after `saveDebounceMs` (default 2000ms) following the last change
+- Immediately when calling `coordinator.flush()`
+
+### What if the bot crashes?
+
+Changes made since the last successful save will be lost. For mission-critical data, consider:
+
+- Shorter debounce interval (e.g., 500ms)
+- Writing to DynamoDB instead of S3
+- Adding backup/versioning to S3 bucket
+
+### Multi-instance deployment?
+
+This design assumes a **single bot instance**. Multiple instances would cause race conditions and data loss. For multi-instance:
+
+- Use DynamoDB with conditional writes
+- Implement optimistic locking with version numbers
+- Use a distributed cache (Redis) as the source of truth
+
+## Example
+
+See `repository-coordinator.example.ts` for a complete working example.

--- a/nodejs/apps/codex/package.json
+++ b/nodejs/apps/codex/package.json
@@ -32,16 +32,20 @@
     "watch": "watch"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.932.0",
     "@dice-roller/rpg-dice-roller": "^5.5.1",
     "@oclif/core": "^4.8.0",
+    "chalk": "^5.6.2",
     "discord.js": "^14.24.2",
-    "dotenv": "^17.2.3"
+    "dotenv": "^17.2.3",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
     "@twin-digital/eslint-config": "workspace:*",
     "@twin-digital/opus-scripts": "workspace:*",
     "@twin-digital/tsconfig": "workspace:*",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "22.x",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/nodejs/apps/codex/src/bot/action.ts
+++ b/nodejs/apps/codex/src/bot/action.ts
@@ -31,10 +31,7 @@ export type BotAction = CreateMessageAction
  */
 export const execute = async (
   action: BotAction,
-  {
-    client,
-    log: _log,
-  }: { client: Client; log: (message?: string, ...args: unknown[]) => void },
+  { client, log: _log }: { client: Client; log: (message?: string, ...args: unknown[]) => void },
 ): Promise<void> => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (action.type === 'create-message') {

--- a/nodejs/apps/codex/src/bot/bot.ts
+++ b/nodejs/apps/codex/src/bot/bot.ts
@@ -1,5 +1,17 @@
-import { Client, GatewayIntentBits, type Message } from 'discord.js'
+import {
+  Client,
+  GatewayIntentBits,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  type Message,
+} from 'discord.js'
 import { execute, type BotAction } from './action.js'
+import { consoleLogger, type Logger } from '../core/log.js'
+import { castArray } from 'lodash-es'
+
+export type CommandHandlerFn = (interaction: ChatInputCommandInteraction, client: Client) => void | Promise<void>
 
 /**
  * Possibly handle a message. If this handler has a response, it will be returned as a `BotAction`. An undefined
@@ -8,9 +20,28 @@ import { execute, type BotAction } from './action.js'
  */
 export type MessageHandlerFn = (
   message: Message,
-) => BotAction | undefined | Promise<BotAction | undefined>
+) => BotAction | BotAction[] | undefined | Promise<BotAction | BotAction[] | undefined>
 
 export interface BotBehavior {
+  /**
+   * Discord slash commands to register for this behavior. The key is the command name, and the value contains
+   * the command description, handler function, and optional parameters.
+   *
+   * When a command is invoked, the corresponding handler will be called with the interaction object.
+   */
+  commands?: Record<
+    string,
+    {
+      description: string
+      handler: CommandHandlerFn
+      options?: {
+        description: string
+        name: string
+        required: boolean
+      }[]
+    }
+  >
+
   /**
    * Set of message handlers implemented by this behavior. When a message is received, each handler will be invoked in
    * turn. If any return a non-undefined result, that action will be invoked and further processing halted. If there are
@@ -19,10 +50,7 @@ export interface BotBehavior {
   messageHandlers?: MessageHandlerFn[]
 }
 
-const registerShutdownHooks = (
-  client: Client,
-  log: (message?: string, ...args: unknown[]) => void,
-) => {
+const registerShutdownHooks = (client: Client, logger: Logger) => {
   let shuttingDown = false
 
   const shutdown = (signal: string) => {
@@ -31,27 +59,27 @@ const registerShutdownHooks = (
     }
 
     shuttingDown = true
-    log(`Received ${signal}, shutting down...`)
+    logger.info(`Received ${signal}, shutting down...`)
     try {
       // remove listeners and destroy the client
       try {
         client.removeAllListeners()
       } catch (e) {
-        log(`Error removing listeners: ${String(e)}`)
+        logger.error(`Error removing listeners: ${String(e)}`)
       }
 
       try {
         void client.destroy()
-        log('Discord client destroyed')
+        logger.info('Discord client destroyed')
       } catch (e) {
-        log(`Error destroying client: ${String(e)}`)
+        logger.error(`Error destroying client: ${String(e)}`)
       }
     } catch (err) {
-      log(`Error during shutdown: ${(err as Error).message}`)
+      logger.error(`Error during shutdown: ${(err as Error).message}`)
     } finally {
       // Give libraries a little time to cleanup, then force exit
       setTimeout(() => {
-        log('Exiting process')
+        logger.info('Exiting process')
         // exit with success; Docker will see the container stop
         process.exit(0)
       }, 25000).unref()
@@ -67,34 +95,89 @@ const registerShutdownHooks = (
 }
 
 export const runBot = async ({
-  appId: _appId,
+  appId,
   behaviors,
-  log = () => {
-    /* noop */
-  },
+  log = consoleLogger,
   token,
 }: {
   appId: string
   behaviors: BotBehavior[]
-  log?: (message?: string, ...args: unknown[]) => void
+  log?: Logger
   token: string
 }): Promise<void> => {
-  log('Initializing Codex bot...')
+  log.info('Initializing Codex bot...')
+
+  // Collect all commands from behaviors
+  const commandMap = new Map<string, CommandHandlerFn>()
+  const slashCommands: ReturnType<SlashCommandBuilder['toJSON']>[] = []
+
+  for (const behavior of behaviors) {
+    if (behavior.commands) {
+      for (const [commandName, commandConfig] of Object.entries(behavior.commands)) {
+        const builder = new SlashCommandBuilder().setName(commandName).setDescription(commandConfig.description)
+
+        // Add options if specified
+        if (commandConfig.options) {
+          for (const option of commandConfig.options) {
+            builder.addStringOption((opt) =>
+              opt.setName(option.name).setDescription(option.description).setRequired(option.required),
+            )
+          }
+        }
+
+        slashCommands.push(builder.toJSON())
+        commandMap.set(commandName, commandConfig.handler)
+      }
+    }
+  }
+
+  // Register slash commands with Discord API
+  if (slashCommands.length > 0) {
+    log.info(`Registering ${slashCommands.length} slash command(s)...`)
+    const rest = new REST({ version: '10' }).setToken(token)
+    try {
+      await rest.put(Routes.applicationCommands(appId), { body: slashCommands })
+      log.info('Successfully registered slash commands')
+    } catch (error) {
+      log.error(`Error registering slash commands: ${(error as Error).message}`)
+    }
+  }
 
   // Setup Discord bot
   const client = new Client({
-    intents: [
-      GatewayIntentBits.Guilds,
-      GatewayIntentBits.GuildMessages,
-      GatewayIntentBits.MessageContent,
-    ],
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
   })
 
   registerShutdownHooks(client, log)
 
   // Handle bot ready event
   client.on('clientReady', () => {
-    log(`Bot logged in as ${client.user?.tag}`)
+    log.info(`Bot logged in as ${client.user?.tag}`)
+  })
+
+  // Handle slash command interactions
+  client.on('interactionCreate', (interaction) => {
+    if (!interaction.isChatInputCommand()) {
+      return
+    }
+
+    void (async () => {
+      try {
+        const handler = commandMap.get(interaction.commandName)
+        if (handler) {
+          await handler(interaction, client)
+        } else {
+          log.error(`No handler found for command: ${interaction.commandName}`)
+          await interaction.reply('I encountered an error processing that command.')
+        }
+      } catch (error) {
+        log.error(`Error handling interaction: ${(error as Error).message}`)
+
+        if (!interaction.replied) {
+          await interaction.reply('I encountered an error processing that command.')
+        }
+      }
+    })()
   })
 
   // Handle messages using the chat handler
@@ -111,21 +194,24 @@ export const runBot = async ({
           for (const messageHandler of messageHandlers) {
             const result = await messageHandler(message)
             if (result !== undefined) {
-              await execute(result, {
-                client,
-                log,
-              })
+              const actions = castArray(result)
+              for (const action of actions) {
+                await execute(action, {
+                  client,
+                  log: log.info.bind(log),
+                })
+              }
               return
             }
           }
         }
       } catch (error) {
-        log(`Error handling message: ${(error as Error).message}`)
+        log.error(`Error handling message: ${(error as Error).message}`)
       }
     })()
   })
 
   // Login to Discord
-  log('Logging into Discord...')
+  log.info('Logging into Discord...')
   await client.login(token)
 }

--- a/nodejs/apps/codex/src/bot/dice-roller/behavior.ts
+++ b/nodejs/apps/codex/src/bot/dice-roller/behavior.ts
@@ -1,29 +1,39 @@
-import { rollOne } from '../../dice/roll.js'
-import type { BotBehavior, MessageHandlerFn } from '../bot.js'
+import type { BotBehavior, CommandHandlerFn, MessageHandlerFn } from '../bot.js'
+import { makeRollStatsHandler } from './interactions/roll-stats.js'
+import { rollOneHandler } from './interactions/roll-one.js'
+import type { RepositoryFactory } from '../../core/db/repository-factory.js'
 
-export const makeDiceRollerBehavior = ({
-  channelIds,
-  log: _log,
-}: {
-  channelIds: string[]
-  log: (message?: string, ...args: unknown[]) => void
-}): BotBehavior => {
-  const diceRollerMessageHandler: MessageHandlerFn = (message) => {
-    if (channelIds.includes(message.channel.id)) {
-      const result = rollOne(message.content)
-      if (result.valid) {
-        return {
-          type: 'create-message',
-          channelId: message.channel.id,
-          content: `${message.author.username} rolled >>> ${result.output}`,
-        }
-      }
-
-      return undefined
+const guardInteractionHandler =
+  (channelIds: string[]) =>
+  (handler: CommandHandlerFn): CommandHandlerFn =>
+  async (interaction, client) => {
+    if (interaction.channel?.id && channelIds.includes(interaction.channel.id)) {
+      await handler(interaction, client)
     }
   }
 
+const guardMessageHandler =
+  (channelIds: string[]) =>
+  (handler: MessageHandlerFn): MessageHandlerFn =>
+  (message) =>
+    channelIds.includes(message.channel.id) ? handler(message) : undefined
+
+export const makeDiceRollerBehavior = ({
+  channelIds,
+  db,
+  log: _log,
+}: {
+  channelIds: string[]
+  db: RepositoryFactory
+  log: (message?: string, ...args: unknown[]) => void
+}): BotBehavior => {
   return {
-    messageHandlers: [diceRollerMessageHandler],
+    commands: {
+      stats: {
+        description: 'Roll character stats, or print the previously rolled set.',
+        handler: guardInteractionHandler(channelIds)(makeRollStatsHandler(db)),
+      },
+    },
+    messageHandlers: [rollOneHandler].map(guardMessageHandler(channelIds)),
   }
 }

--- a/nodejs/apps/codex/src/bot/dice-roller/interactions/roll-one.ts
+++ b/nodejs/apps/codex/src/bot/dice-roller/interactions/roll-one.ts
@@ -1,0 +1,15 @@
+import { rollOne } from '../../../game/dice/roll.js'
+import type { MessageHandlerFn } from '../../bot.js'
+
+export const rollOneHandler: MessageHandlerFn = (message) => {
+  const result = rollOne(message.content)
+  if (result.valid) {
+    return {
+      type: 'create-message',
+      channelId: message.channel.id,
+      content: `${message.author.username} rolled >>> ${result.output}`,
+    }
+  }
+
+  return undefined
+}

--- a/nodejs/apps/codex/src/bot/dice-roller/interactions/roll-stats.ts
+++ b/nodejs/apps/codex/src/bot/dice-roller/interactions/roll-stats.ts
@@ -1,0 +1,167 @@
+import { Chalk } from 'chalk'
+import sum from 'lodash-es/sum.js'
+import type { CommandHandlerFn } from '../../bot.js'
+import type { RepositoryFactory } from '../../../core/db/repository-factory.js'
+import { patchRecord } from '../../../core/db/utils.js'
+import type { Player, PlayerCharacter, PlayerCharacterStatRoll, StatRoll } from '../../../game/model.js'
+import { DefaultPlayerService } from '../../../game/player/player-service.js'
+import { DefaultPlayerCharacterService } from '../../../game/player/player-character-service.js'
+
+// Force ANSI color output even when Node isn't running in a TTY so
+// the generated strings include escape sequences (Discord "```ansi```" blocks
+// will then render the colors). Chalk auto-detects terminal support and may
+// disable colors when not run in a TTY; creating a Chalk instance with
+// level: 3 ensures full color output.
+const chalk = new Chalk({ level: 3 })
+
+const formatStats = (roll: StatRoll) => {
+  const attributeNames = ['STR', 'INT', 'WIS', 'DEX', 'CON', 'CHA']
+  const values = [
+    sum(roll.strength),
+    sum(roll.intelligence),
+    sum(roll.wisdom),
+    sum(roll.dexterity),
+    sum(roll.constitution),
+    sum(roll.charisma),
+  ]
+
+  const toDiceString = (values: number[]) => values.join(' + ')
+  const dice = [
+    toDiceString(roll.strength),
+    toDiceString(roll.intelligence),
+    toDiceString(roll.wisdom),
+    toDiceString(roll.dexterity),
+    toDiceString(roll.constitution),
+    toDiceString(roll.charisma),
+  ]
+
+  // Column content widths (no padding)
+  const statContentWidth = Math.max('Stat'.length, ...attributeNames.map((n) => n.length))
+  const valueContentWidth = Math.max('Val'.length, ...values.map((v) => String(v).length))
+  const diceContentWidth = Math.max('Dice'.length, ...dice.map((d) => d.length))
+
+  // Total column widths include 1 space left + content + 1 space right
+  // For dice column we add two additional spaces on either side (total 3 each side)
+  const statColWidth = statContentWidth + 2
+  const valueColWidth = valueContentWidth + 2
+  const diceColWidth = diceContentWidth + 6
+
+  // Cell renderers
+  const centerCell = (text: string, contentWidth: number) => {
+    const totalPad = contentWidth - text.length
+    const left = Math.floor(totalPad / 2)
+    const right = totalPad - left
+    return ' ' + ' '.repeat(left) + text + ' '.repeat(right) + ' '
+  }
+
+  // Unicode box drawing characters for tighter table
+  const top = '┌' + '─'.repeat(statColWidth) + '┬' + '─'.repeat(valueColWidth) + '┬' + '─'.repeat(diceColWidth) + '┐'
+  const mid = '├' + '─'.repeat(statColWidth) + '┼' + '─'.repeat(valueColWidth) + '┼' + '─'.repeat(diceColWidth) + '┤'
+  const bottom = '└' + '─'.repeat(statColWidth) + '┴' + '─'.repeat(valueColWidth) + '┴' + '─'.repeat(diceColWidth) + '┘'
+
+  // Left-justify Dice header with 3 leading blanks inside the content area
+  // padEnd to match the dice column total width (content + 6) minus the two wrapper spaces
+  const diceHeaderInner = (' '.repeat(4) + 'Rolls').padEnd(diceContentWidth + 4)
+  const header =
+    '│' +
+    centerCell('Stat', statContentWidth) +
+    '│' +
+    centerCell('Val', valueContentWidth) +
+    '│' +
+    ' ' +
+    diceHeaderInner +
+    ' ' +
+    '│'
+
+  const rows = attributeNames.map((name, i) => {
+    const v = values[i]
+    const colorFor = (n: number) =>
+      n < 9 ? chalk.red
+      : n > 12 ? chalk.green
+      : (s: string) => s
+
+    const statPadded = name.padEnd(statContentWidth)
+    const statCell = ' ' + colorFor(v)(statPadded) + ' '
+
+    const valuePadded = String(v).padStart(valueContentWidth)
+    const valueCell = ' ' + colorFor(v)(valuePadded) + ' '
+
+    // dice cell: include 3 spaces on either side and left-justify the dice string within content area
+    const diceCell = ' '.repeat(3) + dice[i].padEnd(diceContentWidth) + ' '.repeat(3)
+    return '│' + statCell + '│' + valueCell + '│' + diceCell + '│'
+  })
+
+  return `\`\`\`ansi
+${top}
+${header}
+${mid}
+${rows.join('\n')}
+${bottom}
+\`\`\`
+`
+}
+
+export const makeRollStatsHandler = (db: RepositoryFactory): CommandHandlerFn => {
+  const playerCharacterStatRolls = db.getRepository<PlayerCharacterStatRoll>('playerCharacterStatRolls')
+  const players = db.getRepository<Player>('players')
+  const pcs = db.getRepository<PlayerCharacter>('playerCharacters')
+
+  const playerService = new DefaultPlayerService(players, pcs)
+  const playerCharacterService = new DefaultPlayerCharacterService(pcs, playerCharacterStatRolls)
+
+  return async (interaction) => {
+    const { character: originalCharacter, player } = await playerService.getPlayerAndCharacter(interaction.user.id)
+
+    if (interaction.user.displayName !== player.displayName) {
+      await patchRecord(players, player.id, {
+        displayName: interaction.user.displayName,
+      })
+    }
+
+    const { results, isNew } = await playerCharacterService.rollStats(originalCharacter.id)
+
+    const formatRolledAt = (iso?: string) => {
+      if (!iso) return 'on unknown date'
+      const d = new Date(iso)
+      try {
+        // Use America/Chicago to represent Central Time (handles DST)
+        const date = new Intl.DateTimeFormat('en-US', {
+          timeZone: 'America/Chicago',
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        }).format(d)
+
+        // 12-hour clock with am/pm
+        const time = new Intl.DateTimeFormat('en-US', {
+          timeZone: 'America/Chicago',
+          hour: 'numeric',
+          minute: '2-digit',
+          hour12: true,
+        })
+          .format(d)
+          .toLowerCase()
+
+        return `on ${date} at ${time}`
+      } catch {
+        // Fallback to manual formatting if Intl timeZone not available
+        const mm = String(d.getMonth() + 1).padStart(2, '0')
+        const dd = String(d.getDate()).padStart(2, '0')
+        const yyyy = d.getFullYear()
+        const hh24 = d.getHours()
+        const period = hh24 >= 12 ? 'pm' : 'am'
+        let hh12 = hh24 % 12
+        if (hh12 === 0) hh12 = 12
+        const min = String(d.getMinutes()).padStart(2, '0')
+        return `on ${mm}/${dd}/${yyyy} at ${hh12}:${min} ${period}`
+      }
+    }
+
+    const preamble =
+      isNew ?
+        `🎉 ${interaction.user.displayName} is creating a new character!`
+      : `${interaction.user.displayName} rolled stats ${formatRolledAt(results.rolledAt)}:`
+
+    await interaction.reply(`${preamble}\n${formatStats(results.rolls)}`)
+  }
+}

--- a/nodejs/apps/codex/src/bot/dice-roller/stats-result.ts
+++ b/nodejs/apps/codex/src/bot/dice-roller/stats-result.ts
@@ -1,0 +1,40 @@
+export interface StatsResult {
+  /**
+   * Unique identifier for this result.
+   */
+  id: string
+
+  /**
+   * ISO-8601 timestamp when the stats were rolled.
+   */
+  rolledAt: string
+
+  /**
+   * Discord ID of the user who rolled the stats.
+   */
+  rolledBy: string
+
+  /**
+   * Individual die results for each stat.
+   */
+  rolls: {
+    strength: number[]
+    intelligence: number[]
+    wisdom: number[]
+    dexterity: number[]
+    constitution: number[]
+    charisma: number[]
+  }
+
+  /**
+   * Total score for each stat.
+   */
+  stats: {
+    strength: number
+    intelligence: number
+    wisdom: number
+    dexterity: number
+    constitution: number
+    charisma: number
+  }
+}

--- a/nodejs/apps/codex/src/core/db/repository-factory.ts
+++ b/nodejs/apps/codex/src/core/db/repository-factory.ts
@@ -1,0 +1,9 @@
+import type { Repository } from './repository.js'
+
+export interface RepositoryFactory {
+  /**
+   * Gets a repository for the specified entity type. Will throw an error if no such repository is available.
+   * @param entityType
+   */
+  getRepository<T extends object>(entityType: string): Repository<T>
+}

--- a/nodejs/apps/codex/src/core/db/repository.ts
+++ b/nodejs/apps/codex/src/core/db/repository.ts
@@ -1,0 +1,29 @@
+/**
+ * A minimal document storage API.
+ */
+export interface Repository<T extends object> {
+  /**
+   * Given the ID of an object, deletes the object from the repository. Will silently do nothing if
+   * the specified ID does not exist.
+   */
+  delete: (id: string) => Promise<void>
+
+  /**
+   * Given the ID of an object, return the object's data.
+   *
+   * @param id id of the object to get
+   * @returns the object, or null if no object exists with the given ID
+   */
+  get: (id: string) => Promise<T | null>
+
+  /**
+   * Returns all objects in this repository.
+   */
+  list: () => Promise<T[]>
+
+  /**
+   * Stores an object in the database, given its ID and data. If an object with the given ID exists, it
+   * will be overwritten with the new data. Otherwise, a new object is created.
+   */
+  upsert: (id: string, data: T) => Promise<void>
+}

--- a/nodejs/apps/codex/src/core/db/s3-repository/document-store.ts
+++ b/nodejs/apps/codex/src/core/db/s3-repository/document-store.ts
@@ -1,0 +1,61 @@
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
+import get from 'lodash-es/get.js'
+import { consoleLogger, type Logger } from '../../log.js'
+
+const s3 = new S3Client({ region: process.env.AWS_REGION })
+
+export class DocumentStore<T extends Record<string, unknown>> {
+  private _log: Logger
+  private _prefix: string
+
+  public constructor(
+    private _bucket: string,
+    { log = consoleLogger, prefix = '' }: { log?: Logger; prefix?: string } = {},
+  ) {
+    this._log = log
+    this._prefix = prefix
+  }
+
+  /**
+   * ID of the document to load
+   * @param id ID
+   * @returns
+   */
+  public async load(id: string): Promise<T> {
+    const key = `${this._prefix}${id}.json`
+
+    try {
+      const res = await s3.send(new GetObjectCommand({ Bucket: this._bucket, Key: key }))
+      const json = (await res.Body?.transformToString()) ?? '{}'
+      return JSON.parse(json) as T
+    } catch (err: unknown) {
+      const obj = err as Record<string, unknown>
+      const name = get(obj, 'name') as string | undefined
+      const httpStatusCode = get(obj, '$metadata.httpStatusCode') as number | undefined
+
+      if (name !== 'NoSuchKey' && httpStatusCode !== 404) {
+        this._log.error(`[DocumentStore] load failed. [id=${id}, prefix=${this._prefix}]`, err)
+      }
+
+      // no data, just return empty object
+      return {} as T
+    }
+  }
+
+  public async save(id: string, data: T): Promise<void> {
+    const key = `${this._prefix}${id}.json`
+
+    try {
+      await s3.send(
+        new PutObjectCommand({
+          Bucket: this._bucket,
+          Key: key,
+          Body: JSON.stringify(data),
+          ContentType: 'application/json',
+        }),
+      )
+    } catch (err) {
+      this._log.error(`[DocumentStore] save failed. [id=${id}, prefix=${this._prefix}]`, err)
+    }
+  }
+}

--- a/nodejs/apps/codex/src/core/db/s3-repository/memory-repository.ts
+++ b/nodejs/apps/codex/src/core/db/s3-repository/memory-repository.ts
@@ -1,0 +1,27 @@
+import type { Repository } from '../repository.js'
+
+/**
+ * Repository implementation that is backed by an in-memory map associating record IDs with values.
+ */
+export class MemoryRepository<T extends object> implements Repository<T> {
+  public constructor(private _data: Map<string, T> = new Map<string, T>()) {}
+
+  public delete(id: string): Promise<void> {
+    this._data.delete(id)
+    return Promise.resolve()
+  }
+
+  public get(id: string): Promise<T | null> {
+    const value = this._data.get(id)
+    return Promise.resolve(value ?? null)
+  }
+
+  public list(): Promise<T[]> {
+    return Promise.resolve(Array.from(this._data.values()))
+  }
+
+  public upsert(id: string, data: T): Promise<void> {
+    this._data.set(id, data)
+    return Promise.resolve()
+  }
+}

--- a/nodejs/apps/codex/src/core/db/s3-repository/repository-coordinator.ts
+++ b/nodejs/apps/codex/src/core/db/s3-repository/repository-coordinator.ts
@@ -1,0 +1,210 @@
+import type { Repository } from '../repository.js'
+import { MemoryRepository } from './memory-repository.js'
+import { DocumentStore } from './document-store.js'
+import type { Logger } from '../../log.js'
+import { consoleLogger } from '../../log.js'
+import type { RepositoryFactory } from '../repository-factory.js'
+
+type EntityKey = string
+
+interface CoordinatorConfig {
+  /**
+   * Name of the S3 bucket in which to save data.
+   */
+  bucket: string
+
+  /**
+   * ID of the document in which the data will be saved. Combined with 'prefix' to form the S3 key.
+   */
+  documentId: string
+
+  /**
+   * Amount of time, in ms, to debounce writes to S3.
+   */
+  saveDebounceMs?: number
+
+  /**
+   * Logger to which messages are sent.
+   */
+  log?: Logger
+
+  /**
+   * S3 prefix in which to store the document.
+   */
+  prefix?: string
+}
+
+/**
+ * Coordinates multiple repositories backed by a single S3 JSON document.
+ *
+ * - All entity types are stored in one document with top-level keys for each type
+ * - Application code uses typed Repository interfaces, unaware of shared storage
+ * - Changes are debounced and persisted to S3 after a configurable delay
+ * - Call flush() before shutdown to ensure pending changes are saved
+ */
+export class RepositoryCoordinator implements RepositoryFactory {
+  private _dirty = false
+  private _documentId: string
+  private _log: Logger
+  private _repositories = new Map<EntityKey, MemoryRepository<object>>()
+  private _saveDebounceMs: number
+  private _saveTimer?: NodeJS.Timeout
+  private _store: DocumentStore<Record<EntityKey, object>>
+
+  public constructor(config: CoordinatorConfig) {
+    this._documentId = config.documentId
+    this._store = new DocumentStore(config.bucket, {
+      prefix: config.prefix ?? '',
+      log: config.log,
+    })
+    this._saveDebounceMs = config.saveDebounceMs ?? 1000
+    this._log = config.log ?? consoleLogger
+  }
+
+  /**
+   * Load the entire document from S3 and populate all repositories.
+   * Must be called before using getRepository().
+   */
+  public async init(): Promise<void> {
+    this._log.info('[RepositoryCoordinator] Loading document from S3')
+    const doc = await this._store.load(this._documentId)
+
+    // Pre-populate all known entity types from the document
+    for (const [key, records] of Object.entries(doc)) {
+      if (typeof records === 'object' && !Array.isArray(records)) {
+        const map = new Map(Object.entries(records as Record<string, object>))
+        this._repositories.set(key, new MemoryRepository(map))
+        this._log.info(`[RepositoryCoordinator] Loaded ${map.size} records for entity type: ${key}`)
+      }
+    }
+
+    this._registerShutdownHooks()
+
+    this._log.info('[RepositoryCoordinator] Initialization complete')
+  }
+
+  /**
+   * Get a repository for a specific entity type. Creates an empty repository
+   * if one doesn't exist yet for this entity key.
+   *
+   * @param entityKey Top-level key in the document (e.g., 'players', 'characters')
+   * @returns Repository instance that triggers saves on mutations
+   */
+  public getRepository<T extends object>(entityKey: EntityKey): Repository<T> {
+    if (!this._repositories.has(entityKey)) {
+      this._log.info(`[RepositoryCoordinator] Creating new repository for entity type: ${entityKey}`)
+      this._repositories.set(entityKey, new MemoryRepository<T>())
+    }
+
+    const repo = this._repositories.get(entityKey)
+    if (!repo) {
+      throw new Error(`[RepositoryCoordinator] Repository not found for entity type: ${entityKey}`)
+    }
+
+    // Wrap the repository to intercept mutations and trigger saves
+    return this._wrapRepository<T>(repo as MemoryRepository<T>)
+  }
+
+  /**
+   * Force an immediate save, bypassing debounce timer.
+   * Call this before shutdown to ensure all changes are persisted.
+   */
+  public async flush(): Promise<void> {
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer)
+      this._saveTimer = undefined
+    }
+    await this._save()
+  }
+
+  /**
+   * Wrap a repository to intercept mutations and trigger debounced saves.
+   * Read operations pass through unchanged.
+   */
+  private _wrapRepository<T extends object>(repo: MemoryRepository<T>): Repository<T> {
+    return {
+      get: (id: string) => repo.get(id),
+      list: () => repo.list(),
+
+      delete: async (id: string) => {
+        await repo.delete(id)
+        this._markDirty()
+      },
+
+      upsert: async (id: string, data: T) => {
+        await repo.upsert(id, data)
+        this._markDirty()
+      },
+    }
+  }
+
+  /**
+   * Mark the coordinator as dirty and schedule a debounced save.
+   * Multiple rapid changes will be batched into a single S3 write.
+   */
+  private _markDirty(): void {
+    this._dirty = true
+
+    // Debounce: clear existing timer and schedule new save
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer)
+    }
+
+    this._saveTimer = setTimeout(() => {
+      void this._save().catch((err: unknown) => {
+        this._log.error('[RepositoryCoordinator] Error during debounced save:', err)
+      })
+    }, this._saveDebounceMs)
+  }
+
+  /**
+   * Serialize all repositories into a single document and save to S3.
+   */
+  private async _save(): Promise<void> {
+    if (!this._dirty) return
+
+    this._log.info('[RepositoryCoordinator] Saving document to S3')
+
+    // Serialize all repositories into a single document
+    const doc: Record<EntityKey, Record<string, unknown>> = {}
+
+    for (const [key, repo] of this._repositories.entries()) {
+      const items = await repo.list()
+
+      // Convert array of items to object keyed by id
+      // Assumes each item has an 'id' property
+      const recordMap: Record<string, unknown> = {}
+      for (const item of items) {
+        const id = typeof item === 'object' && 'id' in item ? (item as { id: unknown }).id : undefined
+        if (typeof id === 'string') {
+          recordMap[id] = item
+        } else {
+          this._log.error(`[RepositoryCoordinator] Skipping item without valid id in entity type: ${key}`, item)
+        }
+      }
+
+      doc[key] = recordMap
+    }
+
+    await this._store.save(this._documentId, doc)
+    this._dirty = false
+    this._log.info('[RepositoryCoordinator] Save complete')
+  }
+
+  private _registerShutdownHooks() {
+    // Setup graceful shutdown to flush pending saves
+    const shutdown = async () => {
+      this._log.info('[RepositoryCoordinator] Saving changes before shutdown...')
+      await this.flush()
+      this._log.info('[RepositoryCoordinator] All changes saved. Goodbye!')
+      process.exit(0)
+    }
+
+    process.on('SIGTERM', () => {
+      void shutdown()
+    })
+    process.on('SIGINT', () => {
+      void shutdown()
+    })
+  }
+}

--- a/nodejs/apps/codex/src/core/db/utils.ts
+++ b/nodejs/apps/codex/src/core/db/utils.ts
@@ -1,0 +1,31 @@
+import { merge } from 'lodash-es'
+import type { Repository } from './repository.js'
+
+export const findOrCreate = async <T extends object>(
+  repository: Repository<T>,
+  id: string,
+  defaultValue?: T,
+): Promise<T> => {
+  const existing = await repository.get(id)
+  const result = existing ?? {
+    ...((defaultValue ?? {}) as T),
+    id,
+  }
+
+  if (existing === null) {
+    await repository.upsert(id, result)
+  }
+
+  return result
+}
+
+export const patchRecord = async <T extends object>(
+  repository: Repository<T>,
+  id: string,
+  patch: Partial<T>,
+): Promise<T> => {
+  const original = await findOrCreate(repository, id)
+  const updated = merge(original, patch) as T
+  await repository.upsert(id, updated)
+  return updated
+}

--- a/nodejs/apps/codex/src/core/log.ts
+++ b/nodejs/apps/codex/src/core/log.ts
@@ -1,0 +1,27 @@
+import { noop } from 'lodash-es'
+
+/**
+ * Type of a function which can be used as a logger.
+ */
+export type LogFn = (message?: string, ...args: unknown[]) => void
+
+export interface Logger {
+  error: LogFn
+  info: LogFn
+}
+
+/**
+ * Logger bound to the console.
+ */
+export const consoleLogger: Logger = {
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+}
+
+/**
+ * Default logger that does nothing.
+ */
+export const noopLogger: Logger = {
+  error: noop,
+  info: noop,
+}

--- a/nodejs/apps/codex/src/game/dice/results.ts
+++ b/nodejs/apps/codex/src/game/dice/results.ts
@@ -1,0 +1,55 @@
+import { Results } from '@dice-roller/rpg-dice-roller'
+
+export interface InvalidRollResult {
+  output?: undefined
+  rolls?: undefined
+  total?: undefined
+  valid: false
+}
+
+export interface ValidRollResult {
+  output: string
+  rolls: (string | number | Results.RollResults | Results.ResultGroup)[]
+  total: number
+  valid: true
+}
+
+export type RollResult = InvalidRollResult | ValidRollResult
+
+/**
+ * Extracts individual die values from a roll result.
+ * Recursively traverses the result structure to find all numeric values.
+ */
+export const extractDieValues = (roll: RollResult): number[] => {
+  const extractNumbers = (node: unknown): number[] => {
+    if (node == null) return []
+    if (typeof node === 'number') return [node]
+    if (typeof node === 'string') {
+      const parsed = Number(node)
+      return !isNaN(parsed) ? [parsed] : []
+    }
+    if (Array.isArray(node)) return node.flatMap((n) => extractNumbers(n))
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (typeof node === 'object' && node !== null) {
+      const obj = node as Record<string, unknown>
+
+      // RollResults: { rolls: [...] }
+      if (Array.isArray(obj.rolls)) {
+        return (obj.rolls as unknown[]).flatMap((r) => extractNumbers(r))
+      }
+
+      // ResultGroup: { results: [...] }
+      if (Array.isArray(obj.results)) {
+        return (obj.results as unknown[]).flatMap((r) => extractNumbers(r))
+      }
+
+      // Some result objects expose a numeric value property
+      if (typeof obj.value === 'number') return [obj.value]
+    }
+
+    return []
+  }
+
+  return roll.valid ? roll.rolls.flatMap((comp) => extractNumbers(comp)) : []
+}

--- a/nodejs/apps/codex/src/game/dice/roll.ts
+++ b/nodejs/apps/codex/src/game/dice/roll.ts
@@ -1,24 +1,12 @@
 import { DiceRoll } from '@dice-roller/rpg-dice-roller'
-
-export interface InvalidRollResult {
-  output?: undefined
-  total?: undefined
-  valid: false
-}
-
-export interface ValidRollResult {
-  output: string
-  total: number
-  valid: true
-}
-
-export type RollResult = InvalidRollResult | ValidRollResult
+import type { RollResult } from './results.js'
 
 export const rollOne = (expression: string): RollResult => {
   try {
     const roll = new DiceRoll(expression)
     return {
       output: roll.output,
+      rolls: roll.rolls,
       total: roll.total,
       valid: true,
     }

--- a/nodejs/apps/codex/src/game/model.ts
+++ b/nodejs/apps/codex/src/game/model.ts
@@ -1,0 +1,111 @@
+export type Player = {
+  /**
+   * ID of the player.
+   */
+  id: string
+} & Partial<{
+  /**
+   * ID of the player's active character, if any.
+   */
+  activeCharacterId: string
+
+  /**
+   * Discord display name, as it was last captured.
+   */
+  displayName?: string
+}>
+
+export type PlayerCharacter = {
+  /**
+   * ID of the character.
+   */
+  id: string
+
+  /**
+   * Player associated with this character.
+   */
+  playerId: string
+} & Partial<{
+  /**
+   * Total score for each stat.
+   */
+  stats: CharacterStats
+
+  /**
+   * ID of the PlayerCharacterStatRoll associated with this character, if any.
+   */
+  statRollId: string
+}>
+
+export type PlayerCharacterWithStats = PlayerCharacter & {
+  /**
+   * Total score for each stat.
+   */
+  stats: CharacterStats
+
+  /**
+   * ID of the PlayerCharacterStatRoll associated with this character, if any.
+   */
+  statRollId: string
+}
+
+export interface CharacterStats {
+  strength: number
+  intelligence: number
+  wisdom: number
+  dexterity: number
+  constitution: number
+  charisma: number
+}
+
+export interface StatRoll {
+  strength: number[]
+  intelligence: number[]
+  wisdom: number[]
+  dexterity: number[]
+  constitution: number[]
+  charisma: number[]
+}
+
+export interface PlayerCharacterStatRoll {
+  /**
+   * Unique identifier for this result.
+   */
+  id: string
+
+  /**
+   * ISO-8601 timestamp when the stats were rolled.
+   */
+  rolledAt: string
+
+  /**
+   * Individual die results for each stat.
+   */
+  rolls: StatRoll
+}
+
+export interface PlayerService {
+  /**
+   * Retrieves the player with the specified Discord id, creating one if needed.
+   */
+  getPlayer(discordPlayerId: string): Promise<Player>
+
+  /**
+   * Retrieves the player with the given discord ID, and their active player character. Both the player, and character,
+   * will be created if they do not already exist.
+   * @param discordPlayerId
+   */
+  getPlayerAndCharacter(discordPlayerId: string): Promise<{ character: PlayerCharacter; player: Player }>
+}
+
+export interface PlayerCharacterService {
+  /**
+   * Rolls stats for the specified character. Will return previously rolled stats if they already exist. `isNew`
+   * indicates if the stats were rolled fresh, or returned from an earlier result. The complete character, with new stats,
+   * is returned.
+   */
+  rollStats(characterId: string): Promise<{
+    results: PlayerCharacterStatRoll
+    isNew: boolean
+  }>
+}

--- a/nodejs/apps/codex/src/game/player/player-character-service.ts
+++ b/nodejs/apps/codex/src/game/player/player-character-service.ts
@@ -1,0 +1,70 @@
+import type { Repository } from '../../core/db/repository.js'
+import { findOrCreate, patchRecord } from '../../core/db/utils.js'
+import { rollOne } from '../../game/dice/roll.js'
+import type {
+  CharacterStats,
+  PlayerCharacter,
+  PlayerCharacterService,
+  PlayerCharacterStatRoll,
+  StatRoll,
+} from '../model.js'
+import { extractDieValues } from '../../game/dice/results.js'
+import { randomUUID } from 'node:crypto'
+import { sum } from 'lodash-es'
+
+export class DefaultPlayerCharacterService implements PlayerCharacterService {
+  public constructor(
+    private _playerCharacters: Repository<PlayerCharacter>,
+    private _playerCharacterStatRolls: Repository<PlayerCharacterStatRoll>,
+  ) {}
+
+  public async rollStats(characterId: string): Promise<{ isNew: boolean; results: PlayerCharacterStatRoll }> {
+    const character = await findOrCreate(this._playerCharacters, characterId)
+
+    const existingRoll: PlayerCharacterStatRoll | null =
+      character.statRollId !== undefined ?
+        ((await this._playerCharacterStatRolls.get(character.statRollId)) ?? null)
+      : null
+
+    const roll = existingRoll ?? (await this._rollNewStats(character.id))
+
+    return {
+      isNew: existingRoll === null,
+      results: roll,
+    }
+  }
+
+  private _rollToStats(roll: StatRoll): CharacterStats {
+    return {
+      strength: sum(roll.strength),
+      intelligence: sum(roll.intelligence),
+      wisdom: sum(roll.wisdom),
+      dexterity: sum(roll.dexterity),
+      constitution: sum(roll.constitution),
+      charisma: sum(roll.charisma),
+    }
+  }
+
+  private async _rollNewStats(characterId: string): Promise<PlayerCharacterStatRoll> {
+    const roll = {
+      id: randomUUID(),
+      rolledAt: new Date().toISOString(),
+      rolls: {
+        strength: extractDieValues(rollOne('3d6')),
+        intelligence: extractDieValues(rollOne('3d6')),
+        wisdom: extractDieValues(rollOne('3d6')),
+        dexterity: extractDieValues(rollOne('3d6')),
+        constitution: extractDieValues(rollOne('3d6')),
+        charisma: extractDieValues(rollOne('3d6')),
+      },
+    }
+
+    await this._playerCharacterStatRolls.upsert(roll.id, roll)
+    await patchRecord(this._playerCharacters, characterId, {
+      statRollId: roll.id,
+      stats: this._rollToStats(roll.rolls),
+    })
+
+    return roll
+  }
+}

--- a/nodejs/apps/codex/src/game/player/player-service.ts
+++ b/nodejs/apps/codex/src/game/player/player-service.ts
@@ -1,0 +1,37 @@
+import { randomUUID } from 'node:crypto'
+import type { Repository } from '../../core/db/repository.js'
+import { findOrCreate, patchRecord } from '../../core/db/utils.js'
+import type { Player, PlayerCharacter, PlayerService } from '../model.js'
+
+export class DefaultPlayerService implements PlayerService {
+  public constructor(
+    private _players: Repository<Player>,
+    private _pcs: Repository<PlayerCharacter>,
+  ) {}
+
+  public async getPlayer(discordPlayerId: string): Promise<Player> {
+    return findOrCreate(this._players, discordPlayerId)
+  }
+
+  public async getPlayerAndCharacter(discordPlayerId: string): Promise<{ character: PlayerCharacter; player: Player }> {
+    const existingPlayer = await this.getPlayer(discordPlayerId)
+    const activeCharacterId = existingPlayer.activeCharacterId ?? randomUUID()
+
+    const character = await findOrCreate(this._pcs, activeCharacterId, {
+      id: activeCharacterId,
+      playerId: existingPlayer.id,
+    })
+
+    const player =
+      existingPlayer.activeCharacterId !== undefined ?
+        existingPlayer
+      : await patchRecord(this._players, discordPlayerId, {
+          activeCharacterId,
+        })
+
+    return {
+      character,
+      player,
+    }
+  }
+}

--- a/nodejs/apps/dolmenwood-bot/src/app/ask-rules-question.ts
+++ b/nodejs/apps/dolmenwood-bot/src/app/ask-rules-question.ts
@@ -60,9 +60,7 @@ function formatPageCitation(meta: DocumentMetadata): string {
   }
 
   // Check if pages are consecutive
-  const isConsecutive = pages.every(
-    (page, i) => i === 0 || page === pages[i - 1] + 1,
-  )
+  const isConsecutive = pages.every((page, i) => i === 0 || page === pages[i - 1] + 1)
 
   if (isConsecutive) {
     return `pp. ${pages[0]}-${pages[pages.length - 1]}`
@@ -79,10 +77,7 @@ function formatPageCitation(meta: DocumentMetadata): string {
 
 function makePrompt(question: string, contexts: Context[]): string {
   const citeBlock = contexts
-    .map(
-      (c, i) =>
-        `#${i + 1} [${c.meta.book} ${formatPageCitation(c.meta)}] ${c.text}`,
-    )
+    .map((c, i) => `#${i + 1} [${c.meta.book} ${formatPageCitation(c.meta)}] ${c.text}`)
     .join('\n---\n')
 
   return `
@@ -110,16 +105,8 @@ FORMAT:
  * @param options Configuration for the question answering process
  * @returns The answer to the question
  */
-export async function askRulesQuestion(
-  options: AskRulesQuestionOptions,
-): Promise<string> {
-  const {
-    knowledgeBase,
-    question,
-    llmModelId,
-    resultCount = 6,
-    maxTokens = 400,
-  } = options
+export async function askRulesQuestion(options: AskRulesQuestionOptions): Promise<string> {
+  const { knowledgeBase, question, llmModelId, resultCount = 6, maxTokens = 400 } = options
 
   // Search for similar chunks
   console.log(`Searching for relevant context (k=${resultCount})...`)

--- a/nodejs/apps/dolmenwood-bot/src/app/knowledge-base.ts
+++ b/nodejs/apps/dolmenwood-bot/src/app/knowledge-base.ts
@@ -1,8 +1,5 @@
 import { invokeEmbeddingModel } from '@twin-digital/bedrock'
-import {
-  createHnswKnowledgeBase,
-  type CreateEmbeddingFn,
-} from '@twin-digital/genai-core'
+import { createHnswKnowledgeBase, type CreateEmbeddingFn } from '@twin-digital/genai-core'
 import type { KnowledgeBase } from '@twin-digital/genai-core'
 
 /**
@@ -19,13 +16,7 @@ export const createBedrockEmbeddingFunction =
     return result.embedding
   }
 
-export const createKnowledgeBase = async (
-  path: string,
-  embeddingModelId: string,
-): Promise<KnowledgeBase> => {
+export const createKnowledgeBase = async (path: string, embeddingModelId: string): Promise<KnowledgeBase> => {
   console.log('modid', embeddingModelId)
-  return await createHnswKnowledgeBase(
-    path,
-    createBedrockEmbeddingFunction(embeddingModelId),
-  )
+  return await createHnswKnowledgeBase(path, createBedrockEmbeddingFunction(embeddingModelId))
 }

--- a/nodejs/apps/dolmenwood-bot/src/commands/bot/ask.ts
+++ b/nodejs/apps/dolmenwood-bot/src/commands/bot/ask.ts
@@ -61,15 +61,10 @@ export default class Ask extends Command {
     this.log(`Loading vector store from ${indexPath}...`)
     let knowledgeBase
     try {
-      knowledgeBase = await createKnowledgeBase(
-        indexPath,
-        flags['embeddings-model'],
-      )
+      knowledgeBase = await createKnowledgeBase(indexPath, flags['embeddings-model'])
     } catch (error) {
       const err = error as Error
-      this.error(
-        `Failed to load vector store from ${indexPath}: ${err.message}`,
-      )
+      this.error(`Failed to load vector store from ${indexPath}: ${err.message}`)
     }
 
     // Ask the question using the shared function

--- a/nodejs/apps/dolmenwood-bot/src/commands/bot/run.ts
+++ b/nodejs/apps/dolmenwood-bot/src/commands/bot/run.ts
@@ -1,11 +1,5 @@
 import { Command, Flags } from '@oclif/core'
-import {
-  Client,
-  GatewayIntentBits,
-  REST,
-  Routes,
-  SlashCommandBuilder,
-} from 'discord.js'
+import { Client, GatewayIntentBits, REST, Routes, SlashCommandBuilder } from 'discord.js'
 import * as path from 'node:path'
 import { createKnowledgeBase } from '../../app/knowledge-base.js'
 import { askRulesQuestion } from '../../app/ask-rules-question.js'
@@ -72,16 +66,11 @@ export default class Run extends Command {
     this.log(`Loading vector store from ${indexPath}...`)
     let knowledgeBase
     try {
-      knowledgeBase = await createKnowledgeBase(
-        indexPath,
-        flags['embeddings-model'],
-      )
+      knowledgeBase = await createKnowledgeBase(indexPath, flags['embeddings-model'])
       this.log('Vector store loaded successfully')
     } catch (error) {
       const err = error as Error
-      this.error(
-        `Failed to load vector store from ${indexPath}: ${err.message}`,
-      )
+      this.error(`Failed to load vector store from ${indexPath}: ${err.message}`)
     }
 
     // Setup Discord bot
@@ -92,9 +81,7 @@ export default class Run extends Command {
       new SlashCommandBuilder()
         .setName('ask')
         .setDescription('Ask a Dolmenwood rules question')
-        .addStringOption((o: any) =>
-          o.setName('q').setDescription('Your question').setRequired(true),
-        ),
+        .addStringOption((o: any) => o.setName('q').setDescription('Your question').setRequired(true)),
     ].map((c: any) => c.toJSON())
 
     // Register slash commands
@@ -112,11 +99,7 @@ export default class Run extends Command {
 
     // Handle interactions
     client.on('interactionCreate', (interaction: any) => {
-      if (
-        !interaction.isChatInputCommand() ||
-        interaction.commandName !== 'ask'
-      )
-        return
+      if (!interaction.isChatInputCommand() || interaction.commandName !== 'ask') return
 
       void (async () => {
         const question = interaction.options.getString('q', true) as string
@@ -134,9 +117,7 @@ export default class Run extends Command {
           await interaction.editReply(answer)
         } catch (error) {
           this.log(`Error answering question: ${(error as Error).message}`)
-          await interaction.editReply(
-            'Sorry—something went wrong retrieving that.',
-          )
+          await interaction.editReply('Sorry—something went wrong retrieving that.')
         }
       })()
     })

--- a/nodejs/apps/dolmenwood-bot/src/commands/rulebooks/download.ts
+++ b/nodejs/apps/dolmenwood-bot/src/commands/rulebooks/download.ts
@@ -1,9 +1,5 @@
 import { Command, Flags } from '@oclif/core'
-import {
-  GetObjectCommand,
-  ListObjectsV2Command,
-  S3Client,
-} from '@aws-sdk/client-s3'
+import { GetObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
 import * as crypto from 'node:crypto'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
@@ -60,10 +56,7 @@ export default class Download extends Command {
     })
   }
 
-  private async streamToFile(
-    stream: Readable,
-    filePath: string,
-  ): Promise<void> {
+  private async streamToFile(stream: Readable, filePath: string): Promise<void> {
     return new Promise((resolve, reject) => {
       const writeStream = fs.createWriteStream(filePath)
       stream.pipe(writeStream)
@@ -79,11 +72,7 @@ export default class Download extends Command {
     return etag.replace(/^"|"$/g, '')
   }
 
-  private async shouldDownload(
-    localPath: string,
-    s3ETag: string,
-    s3Size?: number,
-  ): Promise<boolean> {
+  private async shouldDownload(localPath: string, s3ETag: string, s3Size?: number): Promise<boolean> {
     // If file doesn't exist, download it
     if (!fs.existsSync(localPath)) {
       return true
@@ -141,9 +130,7 @@ export default class Download extends Command {
     }
 
     // Filter for PDF files
-    const pdfObjects = response.Contents.filter((obj: S3Object) =>
-      obj.Key?.toLowerCase().endsWith('.pdf'),
-    )
+    const pdfObjects = response.Contents.filter((obj: S3Object) => obj.Key?.toLowerCase().endsWith('.pdf'))
 
     if (pdfObjects.length === 0) {
       this.warn('No PDF files found')
@@ -164,11 +151,7 @@ export default class Download extends Command {
       const localPath = path.join(outputDir, filename)
 
       // Check if we need to download
-      const needsDownload = await this.shouldDownload(
-        localPath,
-        obj.ETag ?? '',
-        obj.Size,
-      )
+      const needsDownload = await this.shouldDownload(localPath, obj.ETag ?? '', obj.Size)
 
       if (!needsDownload) {
         this.log(`✓ Skipping ${filename} (already exists and is valid)`)
@@ -202,8 +185,6 @@ export default class Download extends Command {
       }
     }
 
-    this.log(
-      `\n✓ Complete: ${downloadedCount} downloaded, ${skippedCount} skipped, ${pdfObjects.length} total`,
-    )
+    this.log(`\n✓ Complete: ${downloadedCount} downloaded, ${skippedCount} skipped, ${pdfObjects.length} total`)
   }
 }

--- a/nodejs/apps/dolmenwood-bot/tsconfig.json
+++ b/nodejs/apps/dolmenwood-bot/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "@twin-digital/tsconfig/tsconfig.build.json",
-    "./tsconfig.options.json"
-  ]
+  "extends": ["@twin-digital/tsconfig/tsconfig.build.json", "./tsconfig.options.json"]
 }

--- a/nodejs/devtools/eslint-config/tsconfig.json
+++ b/nodejs/devtools/eslint-config/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "@twin-digital/tsconfig/tsconfig.build.json",
-    "./tsconfig.options.json"
-  ]
+  "extends": ["@twin-digital/tsconfig/tsconfig.build.json", "./tsconfig.options.json"]
 }

--- a/nodejs/devtools/json-patch-x/src/apply-patch.ts
+++ b/nodejs/devtools/json-patch-x/src/apply-patch.ts
@@ -3,10 +3,7 @@ import type { AnyOperation, ExtendedOperation } from './operations.js'
 import { removeValue } from './operations/remove-value.js'
 import { appendIfMissing } from './operations/append-if-missing.js'
 
-const applyExtendedOperation = <T>(
-  document: T,
-  patch: ExtendedOperation,
-): T => {
+const applyExtendedOperation = <T>(document: T, patch: ExtendedOperation): T => {
   switch (patch.opx) {
     case 'appendIfMissing':
       return appendIfMissing(document, patch.path, patch.value)
@@ -15,16 +12,11 @@ const applyExtendedOperation = <T>(
   }
 }
 
-const applyOperation = <T>(
-  document: T,
-  patch: AnyOperation,
-  index: number,
-): T => {
+const applyOperation = <T>(document: T, patch: AnyOperation, index: number): T => {
   if ('opx' in patch) {
     return applyExtendedOperation(document, patch)
   } else {
-    return jsonPatch.applyOperation(document, patch, true, true, true, index)
-      .newDocument
+    return jsonPatch.applyOperation(document, patch, true, true, true, index).newDocument
   }
 }
 
@@ -39,19 +31,12 @@ const applyOperation = <T>(
  */
 export function applyPatch<T>(document: T, patch: AnyOperation[]): T {
   if (!Array.isArray(patch)) {
-    throw new jsonPatch.JsonPatchError(
-      'Patch sequence must be an array',
-      'SEQUENCE_NOT_AN_ARRAY',
-    )
+    throw new jsonPatch.JsonPatchError('Patch sequence must be an array', 'SEQUENCE_NOT_AN_ARRAY')
   }
 
   let result = jsonPatch.deepClone(document) as T
   for (let i = 0, length = patch.length; i < length; i++) {
-    result = applyOperation(
-      result,
-      jsonPatch.deepClone(patch[i]) as AnyOperation,
-      i,
-    )
+    result = applyOperation(result, jsonPatch.deepClone(patch[i]) as AnyOperation, i)
   }
 
   return result

--- a/nodejs/devtools/json-patch-x/src/operations.ts
+++ b/nodejs/devtools/json-patch-x/src/operations.ts
@@ -10,8 +10,7 @@ export interface BaseExtendedOperation extends BaseOperation {
 /**
  * Appends the specified value to an array, if and only if it does not already exist in the array.
  */
-export interface AppendIfMissingExtendedOperation<T = unknown>
-  extends BaseExtendedOperation {
+export interface AppendIfMissingExtendedOperation<T = unknown> extends BaseExtendedOperation {
   opx: 'appendIfMissing'
 
   /**
@@ -23,8 +22,7 @@ export interface AppendIfMissingExtendedOperation<T = unknown>
 /**
  * Removes all occurrences of a value from an array, leaving any others intact.
  */
-export interface RemoveValueExtendedOperation<T = unknown>
-  extends BaseExtendedOperation {
+export interface RemoveValueExtendedOperation<T = unknown> extends BaseExtendedOperation {
   opx: 'removeValue'
 
   /**
@@ -33,7 +31,5 @@ export interface RemoveValueExtendedOperation<T = unknown>
   value: T
 }
 
-export type ExtendedOperation =
-  | AppendIfMissingExtendedOperation
-  | RemoveValueExtendedOperation
+export type ExtendedOperation = AppendIfMissingExtendedOperation | RemoveValueExtendedOperation
 export type AnyOperation = ExtendedOperation | Operation

--- a/nodejs/devtools/json-patch-x/src/operations/append-if-missing.ts
+++ b/nodejs/devtools/json-patch-x/src/operations/append-if-missing.ts
@@ -1,10 +1,6 @@
 import jsonPatch from 'fast-json-patch'
 
-export const appendIfMissing = <T>(
-  document: T,
-  path: string,
-  value: unknown,
-): T => {
+export const appendIfMissing = <T>(document: T, path: string, value: unknown): T => {
   const array = jsonPatch.getValueByPointer(document, path) as unknown
 
   // no existing array, so add one

--- a/nodejs/devtools/json-patch-x/src/operations/remove-value.ts
+++ b/nodejs/devtools/json-patch-x/src/operations/remove-value.ts
@@ -1,10 +1,6 @@
 import jsonPatch from 'fast-json-patch'
 
-export const removeValue = <T>(
-  document: T,
-  path: string,
-  value: unknown,
-): T => {
+export const removeValue = <T>(document: T, path: string, value: unknown): T => {
   const array = jsonPatch.getValueByPointer(document, path) as unknown
 
   // nothing to remove

--- a/nodejs/devtools/repo-kit/src/cli/commands/sync.ts
+++ b/nodejs/devtools/repo-kit/src/cli/commands/sync.ts
@@ -19,18 +19,14 @@ import fsP from 'node:fs/promises'
 const printResult = (name: string, result: SyncResult) => {
   switch (result.result) {
     case 'error':
-      console.log(
-        `${chalk.redBright('[ERROR]')} ${name}: ${result.error.message}`,
-      )
+      console.log(`${chalk.redBright('[ERROR]')} ${name}: ${result.error.message}`)
 
       console.group()
       console.log(result.error)
       console.groupEnd()
       break
     case 'ok':
-      console.log(
-        `${chalk.greenBright('[CHANGED]')} ${name}: ${chalk.yellow(result.changedFiles.join(', '))}`,
-      )
+      console.log(`${chalk.greenBright('[CHANGED]')} ${name}: ${chalk.yellow(result.changedFiles.join(', '))}`)
       break
     case 'skipped':
       console.log(`${chalk.blue('[OK]')} ${name}`)
@@ -69,9 +65,7 @@ const applyFeatures = async (
         })
       }
     } catch (t: unknown) {
-      console.log(
-        `${chalk.redBright('[ERROR]')} ${feature.name}: ${get(t, 'message', String(t))}`,
-      )
+      console.log(`${chalk.redBright('[ERROR]')} ${feature.name}: ${get(t, 'message', String(t))}`)
 
       console.group()
       console.error(t)
@@ -90,11 +84,7 @@ const applyFeatures = async (
  * @param changedFiles Array of files that were changed during sync (relative to package root)
  * @throws Error if the hook command fails
  */
-const applyHookIfNeeded = async (
-  hook: HookConfig,
-  pkg: PackageMeta,
-  changedFiles: string[],
-): Promise<void> => {
+const applyHookIfNeeded = async (hook: HookConfig, pkg: PackageMeta, changedFiles: string[]): Promise<void> => {
   // Find files matching the hook's pattern and check if any changed files match
   const matchingFiles: string[] = []
   for await (const file of fsP.glob(hook.path, { cwd: pkg.path })) {
@@ -122,11 +112,7 @@ const applyHookIfNeeded = async (
  * @param changedFiles Array of files that were changed during sync (relative to package root)
  * @throws Error if any hooks fail during execution
  */
-const applyHooks = async (
-  pkg: PackageMeta,
-  config: Configuration,
-  changedFiles: string[],
-): Promise<void> => {
+const applyHooks = async (pkg: PackageMeta, config: Configuration, changedFiles: string[]): Promise<void> => {
   const hooks = config.hooks ?? []
   if (hooks.length === 0 || changedFiles.length === 0) {
     return
@@ -140,9 +126,7 @@ const applyHooks = async (
     } catch (error: unknown) {
       const hookLabel = hook.description ?? hook.run
       const errorMessage = get(error, 'message', String(error))
-      console.log(
-        `${chalk.redBright('[ERROR]')} Hook failed: ${hookLabel}: ${errorMessage}`,
-      )
+      console.log(`${chalk.redBright('[ERROR]')} Hook failed: ${hookLabel}: ${errorMessage}`)
       errors.push({ hook: hookLabel, error })
     }
   }
@@ -184,12 +168,6 @@ const handler = async (options: { config: string }) => {
 
 export const makeCommand = (): Command =>
   new Command('sync')
-    .description(
-      'updates project configuration files (package.json, etc.) to align with repo-kit conventions',
-    )
-    .option(
-      '--config <path>',
-      'path to repo-kit configuration file',
-      '.repo-kit.yml',
-    )
+    .description('updates project configuration files (package.json, etc.) to align with repo-kit conventions')
+    .option('--config <path>', 'path to repo-kit configuration file', '.repo-kit.yml')
     .action(handler)

--- a/nodejs/devtools/repo-kit/src/cli/commands/update-readme.ts
+++ b/nodejs/devtools/repo-kit/src/cli/commands/update-readme.ts
@@ -97,7 +97,5 @@ const handler = async () => {
 
 export const makeCommand = (): Command =>
   new Command('update-readme')
-    .description(
-      'updates the project README.md file to include updated descriptions of all packages',
-    )
+    .description('updates the project README.md file to include updated descriptions of all packages')
     .action(handler)

--- a/nodejs/devtools/repo-kit/src/cli/entry-point.ts
+++ b/nodejs/devtools/repo-kit/src/cli/entry-point.ts
@@ -11,15 +11,11 @@ const importTopLevelFunction = async (
   const mod = (await import(modulePath)) as Record<string, unknown>
 
   if (!(functionName in mod)) {
-    throw new Error(
-      `Invalid command module: no top-level ${functionName} function. [module=${modulePath}]`,
-    )
+    throw new Error(`Invalid command module: no top-level ${functionName} function. [module=${modulePath}]`)
   }
 
   if (typeof mod[functionName] !== 'function') {
-    throw new Error(
-      `Invalid command module: ${functionName} was not a function. [module=${modulePath}]`,
-    )
+    throw new Error(`Invalid command module: ${functionName} was not a function. [module=${modulePath}]`)
   }
 
   return mod[functionName] as (...args: unknown[]) => unknown
@@ -39,24 +35,17 @@ const registerCommands = async (program: Command) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       program.addCommand(command)
     } else {
-      throw new Error(
-        `Invalid command module: "makeCommand" did not return a Command object. [module=${modulePath}]`,
-      )
+      throw new Error(`Invalid command module: "makeCommand" did not return a Command object. [module=${modulePath}]`)
     }
   }
 }
 
 const main = async () => {
   const packageJson = JSON.parse(
-    fs.readFileSync(
-      path.join(import.meta.dirname, '..', '..', 'package.json'),
-      'utf-8',
-    ),
+    fs.readFileSync(path.join(import.meta.dirname, '..', '..', 'package.json'), 'utf-8'),
   ) as { version: string | undefined }
 
-  const program = new Command()
-    .name('repo-kit')
-    .version(packageJson.version ?? 'unknown')
+  const program = new Command().name('repo-kit').version(packageJson.version ?? 'unknown')
 
   await registerCommands(program)
   await program.parseAsync(process.argv)
@@ -69,10 +58,7 @@ process.on('warning', (warning) => {
   // suppress warnings for experimental 'glob' feature we are using, iff:
   //   - name is ExperimentalWarning
   //   - message mentions the glob API
-  if (
-    warning.name === 'ExperimentalWarning' &&
-    warning.message.includes('glob')
-  ) {
+  if (warning.name === 'ExperimentalWarning' && warning.message.includes('glob')) {
     return
   }
 
@@ -91,9 +77,7 @@ main().catch((err: unknown) => {
   console.error(
     '--------------------------------------------------------------------------------------------------------------',
   )
-  console.error(
-    `Command failed: ${err instanceof Error ? err.message : String(err)}`,
-  )
+  console.error(`Command failed: ${err instanceof Error ? err.message : String(err)}`)
   console.error('See previous output for more details.')
   process.exit(1)
 })

--- a/nodejs/devtools/repo-kit/src/config/assets.ts
+++ b/nodejs/devtools/repo-kit/src/config/assets.ts
@@ -9,8 +9,7 @@ const ASSETS_ROOT = path.join(import.meta.dirname, 'assets')
  * @param asset Name of the asset, relative to the root asset directory and with no leading slash.
  * @returns Absolute path to the asset file.
  */
-export const getAssetPath = (asset: string): string =>
-  path.join(ASSETS_ROOT, asset)
+export const getAssetPath = (asset: string): string => path.join(ASSETS_ROOT, asset)
 
 /**
  * Loads the named asset, and parses it as a JSON string. Returns the parsing result.
@@ -27,8 +26,7 @@ export const loadJsonAsset = async <T = unknown>(asset: string): Promise<T> => {
  * @param asset Name of the asset, relative to the root asset directory
  * @returns Content of the asset
  */
-export const loadTextAsset = (asset: string): Promise<string> =>
-  fsP.readFile(getAssetPath(asset), 'utf-8')
+export const loadTextAsset = (asset: string): Promise<string> => fsP.readFile(getAssetPath(asset), 'utf-8')
 
 /**
  * Loads the named asset, and parses it as a YAML string. Returns the parsing result.

--- a/nodejs/devtools/repo-kit/src/config/repo-kit-configuration.ts
+++ b/nodejs/devtools/repo-kit/src/config/repo-kit-configuration.ts
@@ -57,10 +57,7 @@ export interface NotExistsConditionConfig {
  * A condition used to determine if a sync feature (or a specific action within a feature) will be applied to a package
  * or not.
  */
-export type SyncConditionConfig =
-  | DependencyConditionConfig
-  | ExistsConditionConfig
-  | NotExistsConditionConfig
+export type SyncConditionConfig = DependencyConditionConfig | ExistsConditionConfig | NotExistsConditionConfig
 
 /**
  * Configuration for a hook that runs after files are changed during sync.
@@ -232,9 +229,7 @@ export interface Configuration {
 /**
  * Loads the repo-kit configuration, with any defaults applied.
  */
-export const loadConfig = async (
-  configPath: string,
-): Promise<Configuration> => {
+export const loadConfig = async (configPath: string): Promise<Configuration> => {
   const content = await fsP.readFile(path.resolve(configPath), 'utf-8')
   return {
     hooks: [],

--- a/nodejs/devtools/repo-kit/src/configuration/configuration-loader.ts
+++ b/nodejs/devtools/repo-kit/src/configuration/configuration-loader.ts
@@ -8,11 +8,7 @@ import yaml from 'yaml'
  * Function which is able to load configuration from an implementation-specific source. Will return undefined if the
  * underlying source of configuration data does not exist.
  */
-export type ConfigurationLoaderFn = () =>
-  | ConfigValue
-  | Promise<ConfigValue>
-  | undefined
-  | Promise<undefined>
+export type ConfigurationLoaderFn = () => ConfigValue | Promise<ConfigValue> | undefined | Promise<undefined>
 
 /**
  * Returns a `ConfigurationLoaderFn` which reads configuration from a specified file.
@@ -36,10 +32,7 @@ export const makeJsonFileLoader =
  * @param key Key (or array of nested keys) of the config value to select.
  */
 export const makeKeySelector =
-  (
-    key: string | string[],
-    delegateLoader: ConfigurationLoaderFn,
-  ): ConfigurationLoaderFn =>
+  (key: string | string[], delegateLoader: ConfigurationLoaderFn): ConfigurationLoaderFn =>
   async () => {
     const allConfig = await delegateLoader()
     return get(allConfig, key) as ConfigValue
@@ -69,14 +62,8 @@ export const makeLoaderChain =
  * @param key Key to return from the package.json file
  * @param packagePath Package path, containing the package.json file
  */
-export const makePackageJsonLoader = (
-  key: string | string[],
-  packagePath: string,
-): ConfigurationLoaderFn =>
-  makeKeySelector(
-    key,
-    makeJsonFileLoader(path.join(packagePath, 'package.json')),
-  )
+export const makePackageJsonLoader = (key: string | string[], packagePath: string): ConfigurationLoaderFn =>
+  makeKeySelector(key, makeJsonFileLoader(path.join(packagePath, 'package.json')))
 
 /**
  * Returns a `ConfigurationLoaderFn` which reads configuration from a specified Yaml file.

--- a/nodejs/devtools/repo-kit/src/configuration/configuration.ts
+++ b/nodejs/devtools/repo-kit/src/configuration/configuration.ts
@@ -6,7 +6,4 @@ export type ConfigPrimitive = string | number | boolean | null | undefined
 /**
  * A configuration value consisting of config primitives, or arrays or string-keyed records of the same.
  */
-export type ConfigValue =
-  | ConfigPrimitive
-  | { [key: string]: ConfigValue }
-  | ConfigValue[]
+export type ConfigValue = ConfigPrimitive | { [key: string]: ConfigValue } | ConfigValue[]

--- a/nodejs/devtools/repo-kit/src/configuration/package-config-loader.ts
+++ b/nodejs/devtools/repo-kit/src/configuration/package-config-loader.ts
@@ -28,10 +28,7 @@ import {
  * @param packagePath Path of the package root, containing `package.json`
  * @returns The loaded configuration, or undefined if no such configuration exists.
  */
-export const makePackageConfigLoader = (
-  configName: string,
-  packagePath: string,
-): ConfigurationLoaderFn =>
+export const makePackageConfigLoader = (configName: string, packagePath: string): ConfigurationLoaderFn =>
   makeLoaderChain(
     makePackageJsonLoader(configName, packagePath),
     makeYamlFileLoader(path.join(packagePath, `.${configName}.yaml`)),

--- a/nodejs/devtools/repo-kit/src/markdown/update-section.ts
+++ b/nodejs/devtools/repo-kit/src/markdown/update-section.ts
@@ -47,18 +47,12 @@ export const updateSection = ({
   const getUpdatedContent = () => {
     const beginMarker = `<!-- BEGIN ${sectionId} -->`
     const endMarker = `<!-- END ${sectionId} -->`
-    const sectionRegExp = new RegExp(
-      `${escapeRegExp(beginMarker)}[\\s\\S]*?${escapeRegExp(endMarker)}`,
-      'g',
-    )
+    const sectionRegExp = new RegExp(`${escapeRegExp(beginMarker)}[\\s\\S]*?${escapeRegExp(endMarker)}`, 'g')
 
     const sectionExists = !!sectionRegExp.exec(markdown)
     if (sectionExists) {
       // section exists, so let's update it
-      return markdown.replaceAll(
-        sectionRegExp,
-        `${beginMarker}\n\n${content}\n\n${endMarker}`,
-      )
+      return markdown.replaceAll(sectionRegExp, `${beginMarker}\n\n${content}\n\n${endMarker}`)
     } else {
       switch (missing) {
         case 'insert':
@@ -66,9 +60,7 @@ export const updateSection = ({
         case 'skip':
           return markdown
         default:
-          throw new Error(
-            `Could not find section to update, and 'missing' was "${missing}. [sectionId=${sectionId}]`,
-          )
+          throw new Error(`Could not find section to update, and 'missing' was "${missing}. [sectionId=${sectionId}]`)
       }
     }
   }

--- a/nodejs/devtools/repo-kit/src/sync/actions/json-merge-patch.ts
+++ b/nodejs/devtools/repo-kit/src/sync/actions/json-merge-patch.ts
@@ -45,16 +45,10 @@ export const makeJsonMergePatchAction =
     const content = await fsP.readFile(filePath, 'utf-8')
     const original = JSON.parse(content) as object
     const parsedPatch = yaml.parse(patch) as object
-    const patched = removeEmptyValues(
-      jsonMergePatch.apply(cloneDeep(original), parsedPatch),
-    )
+    const patched = removeEmptyValues(jsonMergePatch.apply(cloneDeep(original), parsedPatch))
 
     if (!isEqual(patched, original)) {
-      await fsP.writeFile(
-        filePath,
-        `${JSON.stringify(patched, null, 2)}\n`,
-        'utf-8',
-      )
+      await fsP.writeFile(filePath, `${JSON.stringify(patched, null, 2)}\n`, 'utf-8')
       return {
         changedFiles: [file],
         result: 'ok',

--- a/nodejs/devtools/repo-kit/src/sync/actions/json-patch.ts
+++ b/nodejs/devtools/repo-kit/src/sync/actions/json-patch.ts
@@ -42,11 +42,7 @@ export const makeJsonPatchAction =
     const patched = removeEmptyValues(applyPatch(original, parsedPatch))
 
     if (!isEqual(patched, original)) {
-      await fsP.writeFile(
-        filePath,
-        `${JSON.stringify(patched, null, 2)}\n`,
-        'utf-8',
-      )
+      await fsP.writeFile(filePath, `${JSON.stringify(patched, null, 2)}\n`, 'utf-8')
       return {
         changedFiles: [file],
         result: 'ok',

--- a/nodejs/devtools/repo-kit/src/sync/actions/write-file.ts
+++ b/nodejs/devtools/repo-kit/src/sync/actions/write-file.ts
@@ -24,10 +24,7 @@ export const makeWriteFileAction =
   }): SyncActionFn =>
   async (workspace) => {
     const filePath = path.join(workspace.path, file)
-    const previousContent =
-      fs.existsSync(filePath) ?
-        await fsP.readFile(filePath, 'utf-8')
-      : undefined
+    const previousContent = fs.existsSync(filePath) ? await fsP.readFile(filePath, 'utf-8') : undefined
     const changed = previousContent === undefined || previousContent !== content
 
     if (changed) {

--- a/nodejs/devtools/repo-kit/src/sync/conditions/dependency-condition.ts
+++ b/nodejs/devtools/repo-kit/src/sync/conditions/dependency-condition.ts
@@ -43,35 +43,19 @@ export const makeDependencyCondition =
   (workspace) => {
     const manifest: ProjectManifest = workspace.manifest
 
-    if (
-      dependency &&
-      manifest.dependencies &&
-      dependencyName in manifest.dependencies
-    ) {
+    if (dependency && manifest.dependencies && dependencyName in manifest.dependencies) {
       return true
     }
 
-    if (
-      devDependency &&
-      manifest.devDependencies &&
-      dependencyName in manifest.devDependencies
-    ) {
+    if (devDependency && manifest.devDependencies && dependencyName in manifest.devDependencies) {
       return true
     }
 
-    if (
-      optionalDependency &&
-      manifest.optionalDependencies &&
-      dependencyName in manifest.optionalDependencies
-    ) {
+    if (optionalDependency && manifest.optionalDependencies && dependencyName in manifest.optionalDependencies) {
       return true
     }
 
-    if (
-      peerDependency &&
-      manifest.peerDependencies &&
-      dependencyName in manifest.peerDependencies
-    ) {
+    if (peerDependency && manifest.peerDependencies && dependencyName in manifest.peerDependencies) {
       return true
     }
 

--- a/nodejs/devtools/repo-kit/src/utils/glob-matches.ts
+++ b/nodejs/devtools/repo-kit/src/utils/glob-matches.ts
@@ -8,10 +8,7 @@ import fsP from 'node:fs/promises'
  * @param cwd Working directory from which to match files, defaulting to cwd
  * @return true if the glob(s) match at least one file, otherwise false
  */
-export async function globMatches(
-  pattern: string | string[],
-  cwd: string = process.cwd(),
-): Promise<boolean> {
+export async function globMatches(pattern: string | string[], cwd: string = process.cwd()): Promise<boolean> {
   const iterator = fsP.glob(pattern, {
     cwd,
   })

--- a/nodejs/devtools/repo-kit/src/utils/remove-empty-values.ts
+++ b/nodejs/devtools/repo-kit/src/utils/remove-empty-values.ts
@@ -39,8 +39,7 @@ export const removeEmptyValues = (obj: unknown): unknown => {
           const cleaned = recurse(v)
 
           const isEmptyArr = Array.isArray(cleaned) && cleaned.length === 0
-          const isEmptyObj =
-            isPlainObject(cleaned) && keys(cleaned).length === 0
+          const isEmptyObj = isPlainObject(cleaned) && keys(cleaned).length === 0
 
           if (cleaned !== undefined && !isEmptyArr && !isEmptyObj) {
             out[k] = cleaned

--- a/nodejs/devtools/repo-kit/src/workspace/find-packages.ts
+++ b/nodejs/devtools/repo-kit/src/workspace/find-packages.ts
@@ -23,17 +23,12 @@ export const findPackages = async ({
 
   const rootPath = await getWorkspaceRoot()
   const allPackages = JSON.parse(stdout) as { name: string; path: string }[]
-  const packages =
-    includeRoot ? allPackages : (
-      allPackages.filter((pkg) => pkg.path !== rootPath)
-    )
+  const packages = includeRoot ? allPackages : allPackages.filter((pkg) => pkg.path !== rootPath)
 
   return Promise.all(
     packages.map(async (pkg) => {
       const manifestPath = path.resolve(pkg.path, 'package.json')
-      const manifest = JSON.parse(
-        await fs.promises.readFile(manifestPath, 'utf-8'),
-      ) as ProjectManifest
+      const manifest = JSON.parse(await fs.promises.readFile(manifestPath, 'utf-8')) as ProjectManifest
       return {
         manifest,
         name: pkg.name,

--- a/nodejs/devtools/repo-kit/src/workspace/get-current-package.ts
+++ b/nodejs/devtools/repo-kit/src/workspace/get-current-package.ts
@@ -35,19 +35,14 @@ const findNearestPackageJson = (startDir: string): string | null => {
  *
  * @param cwd - Directory for which to find the package (defaults to process.cwd())
  */
-export const getCurrentPackage = async (
-  cwd: string = process.cwd(),
-): Promise<PackageMeta> => {
+export const getCurrentPackage = async (cwd: string = process.cwd()): Promise<PackageMeta> => {
   const packageDir = findNearestPackageJson(cwd)
   if (packageDir === null) {
     throw new Error(`No package.json found in any ancestor of "${cwd}".`)
   }
 
   const manifest = JSON.parse(
-    await fs.promises.readFile(
-      path.resolve(packageDir, 'package.json'),
-      'utf-8',
-    ),
+    await fs.promises.readFile(path.resolve(packageDir, 'package.json'), 'utf-8'),
   ) as PackageManifest
 
   return {

--- a/nodejs/devtools/repo-kit/src/workspace/get-workspace-root.ts
+++ b/nodejs/devtools/repo-kit/src/workspace/get-workspace-root.ts
@@ -4,9 +4,7 @@ import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 export const getWorkspaceRoot = async (): Promise<string> => {
   const root = await findWorkspaceDir(process.cwd())
   if (!root) {
-    throw new Error(
-      `Could not determine workspace root. [cwd=${process.cwd()}]`,
-    )
+    throw new Error(`Could not determine workspace root. [cwd=${process.cwd()}]`)
   }
 
   return root

--- a/nodejs/genai/bedrock/src/embedding/embedding-api.ts
+++ b/nodejs/genai/bedrock/src/embedding/embedding-api.ts
@@ -26,10 +26,7 @@ export interface EmbeddingResponse {
 /**
  * Model adapter interface for embedding models.
  */
-export interface EmbeddingModelAdapter<
-  TRequest = unknown,
-  TResponse = unknown,
-> {
+export interface EmbeddingModelAdapter<TRequest = unknown, TResponse = unknown> {
   /**
    * Converts a generic {@see EmbeddingRequest} to a model-specific input body.
    */

--- a/nodejs/genai/bedrock/src/embedding/invoke.ts
+++ b/nodejs/genai/bedrock/src/embedding/invoke.ts
@@ -9,10 +9,7 @@ import { getEmbeddingModelAdapter } from './model-adapters.js'
  * @param request Request input containing the string to embed.
  * @returns The generated embeddings.
  */
-export const invokeEmbeddingModel = async (
-  modelId: string,
-  request: EmbeddingRequest,
-): Promise<EmbeddingResponse> => {
+export const invokeEmbeddingModel = async (modelId: string, request: EmbeddingRequest): Promise<EmbeddingResponse> => {
   const adapter = getEmbeddingModelAdapter(modelId)
   if (adapter === undefined) {
     throw new Error(`No adapter found for model: ${modelId}`)
@@ -26,8 +23,6 @@ export const invokeEmbeddingModel = async (
     }),
   )
 
-  const responseBody = JSON.parse(
-    new TextDecoder().decode(response.body),
-  ) as unknown
+  const responseBody = JSON.parse(new TextDecoder().decode(response.body)) as unknown
   return adapter.parseResponse(responseBody)
 }

--- a/nodejs/genai/bedrock/src/embedding/model-adapters.ts
+++ b/nodejs/genai/bedrock/src/embedding/model-adapters.ts
@@ -13,11 +13,7 @@ const embeddingModelAdapters = [
  * @param modelId The Bedrock model ID
  * @returns The matching adapter, or undefined if no adapter matches
  */
-export const getEmbeddingModelAdapter = (
-  modelId: string,
-): EmbeddingModelAdapter | undefined => {
-  const matched = embeddingModelAdapters.find((entry) =>
-    entry.match.test(modelId),
-  )
+export const getEmbeddingModelAdapter = (modelId: string): EmbeddingModelAdapter | undefined => {
+  const matched = embeddingModelAdapters.find((entry) => entry.match.test(modelId))
   return matched?.adapter
 }

--- a/nodejs/genai/bedrock/src/embedding/models/amazon/titan-embed-text.ts
+++ b/nodejs/genai/bedrock/src/embedding/models/amazon/titan-embed-text.ts
@@ -57,10 +57,7 @@ export interface TitanEmbedTextResponse {
   }
 }
 
-export const adapter: EmbeddingModelAdapter<
-  TitanEmbedTextRequest,
-  TitanEmbedTextResponse
-> = {
+export const adapter: EmbeddingModelAdapter<TitanEmbedTextRequest, TitanEmbedTextResponse> = {
   createRequest: (request) => request,
 
   parseResponse: (response) => {

--- a/nodejs/genai/bedrock/src/inference/invoke.ts
+++ b/nodejs/genai/bedrock/src/inference/invoke.ts
@@ -9,10 +9,7 @@ import { getModelAdapter } from './model-adapters.js'
  * @param request Request input containing the prompt and generation parameters.
  * @returns The generated text response.
  */
-export const invokeInferenceModel = async (
-  modelId: string,
-  request: InferenceRequest,
-): Promise<InferenceResponse> => {
+export const invokeInferenceModel = async (modelId: string, request: InferenceRequest): Promise<InferenceResponse> => {
   const adapter = getModelAdapter(modelId)
   if (adapter === undefined) {
     throw new Error(`No adapter found for model: ${modelId}`)
@@ -26,8 +23,6 @@ export const invokeInferenceModel = async (
     }),
   )
 
-  const responseBody = JSON.parse(
-    new TextDecoder().decode(response.body),
-  ) as unknown
+  const responseBody = JSON.parse(new TextDecoder().decode(response.body)) as unknown
   return adapter.parseResponse(responseBody)
 }

--- a/nodejs/genai/bedrock/src/inference/model-adapters.ts
+++ b/nodejs/genai/bedrock/src/inference/model-adapters.ts
@@ -13,9 +13,7 @@ const modelAdapters = [
   },
 ]
 
-export const getModelAdapter = (
-  modelId: string,
-): ModelApiAdapter | undefined => {
+export const getModelAdapter = (modelId: string): ModelApiAdapter | undefined => {
   const matched = modelAdapters.find((entry) => entry.match.test(modelId))
   return matched?.adapter
 }

--- a/nodejs/genai/bedrock/src/inference/models/anthropic/claude.ts
+++ b/nodejs/genai/bedrock/src/inference/models/anthropic/claude.ts
@@ -33,11 +33,7 @@ export interface ClaudeMessage {
  * @see https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html
  */
 export interface ClaudeTool {
-  type:
-    | 'custom'
-    | 'computer_20241022'
-    | 'bash_20241022'
-    | 'text_editor_20241022'
+  type: 'custom' | 'computer_20241022' | 'bash_20241022' | 'text_editor_20241022'
   name: string
   description?: string
   input_schema?: unknown

--- a/nodejs/genai/genai-core/src/knowledge-base.ts
+++ b/nodejs/genai/genai-core/src/knowledge-base.ts
@@ -1,9 +1,5 @@
 import type { VectorStore } from '@langchain/core/vectorstores'
-import type {
-  KnowledgeBase,
-  KnowledgeBaseSearchOptions,
-  KnowledgeBaseSearchResult,
-} from './rag.js'
+import type { KnowledgeBase, KnowledgeBaseSearchOptions, KnowledgeBaseSearchResult } from './rag.js'
 import { HNSWLib } from '@langchain/community/vectorstores/hnswlib'
 
 /**
@@ -48,8 +44,7 @@ export const createHnswKnowledgeBase = async (
 ): Promise<KnowledgeBase> => {
   const store = await HNSWLib.load(storePath, {
     embedQuery: createEmbedding,
-    embedDocuments: async (texts: string[]) =>
-      Promise.all(texts.map((t) => createEmbedding(t))),
+    embedDocuments: async (texts: string[]) => Promise.all(texts.map((t) => createEmbedding(t))),
   })
   return new VectorStoreKnowledgeBase(store)
 }

--- a/nodejs/genai/genai-core/src/rag.ts
+++ b/nodejs/genai/genai-core/src/rag.ts
@@ -1,13 +1,7 @@
 /**
  * Represents all possible JSON types
  */
-export type JsonType =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonType[]
-  | { [key: string]: JsonType }
+export type JsonType = string | number | boolean | null | JsonType[] | { [key: string]: JsonType }
 
 /**
  * Options for configuring a knowledge base search query.
@@ -56,8 +50,5 @@ export interface KnowledgeBase {
    * @param options Additional options to control how the query is performed.
    * @returns Promise resolving to an array of search results, ordered by relevance.
    */
-  search(
-    query: string,
-    options?: KnowledgeBaseSearchOptions,
-  ): Promise<KnowledgeBaseSearchResult[]>
+  search(query: string, options?: KnowledgeBaseSearchOptions): Promise<KnowledgeBaseSearchResult[]>
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,18 +74,27 @@ importers:
 
   nodejs/apps/codex:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.932.0
+        version: 3.932.0
       '@dice-roller/rpg-dice-roller':
         specifier: ^5.5.1
         version: 5.5.1
       '@oclif/core':
         specifier: ^4.8.0
         version: 4.8.0
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
       discord.js:
         specifier: ^14.24.2
         version: 14.24.2
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
@@ -99,6 +108,9 @@ importers:
       '@twin-digital/tsconfig':
         specifier: workspace:*
         version: link:../../devtools/tsconfig
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/node':
         specifier: 22.x
         version: 22.14.0
@@ -2247,9 +2259,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -2582,6 +2591,10 @@ packages:
 
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chardet@2.1.1:
@@ -6260,8 +6273,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/estree@1.0.7': {}
-
   '@types/estree@1.0.8': {}
 
   '@types/json-merge-patch@1.0.0': {}
@@ -6307,7 +6318,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.19.1
 
   '@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
@@ -6699,6 +6710,8 @@ snapshots:
 
   chalk@5.4.1: {}
 
+  chalk@5.6.2: {}
+
   chardet@2.1.1: {}
 
   check-error@2.1.1: {}
@@ -6977,7 +6990,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.2
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
@@ -7358,7 +7371,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -7924,7 +7937,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.13.2):
     dependencies:
       axios: 1.13.2(debug@4.4.3)
 

--- a/tooling/scripts/bin/clean.js
+++ b/tooling/scripts/bin/clean.js
@@ -5,12 +5,7 @@ import { resolve } from 'node:path'
 import { globby } from 'globby'
 
 const projectRoot = resolve(process.cwd())
-const patterns = [
-  '**/dist',
-  '**/.turbo',
-  '**/tsconfig.tsbuildinfo',
-  '!**/node_modules/**',
-]
+const patterns = ['**/dist', '**/.turbo', '**/tsconfig.tsbuildinfo', '!**/node_modules/**']
 
 try {
   const files = await globby(patterns, {

--- a/tooling/scripts/bin/docker-packages.js
+++ b/tooling/scripts/bin/docker-packages.js
@@ -51,10 +51,7 @@ async function main() {
       // Find package directory by searching package.json files
       const packageJsonPath = await findPackageJson(packageName)
       if (!packageJsonPath) {
-        console.error(
-          `Warning: Could not find package.json for ${packageName}`,
-          { stderr: true },
-        )
+        console.error(`Warning: Could not find package.json for ${packageName}`, { stderr: true })
         continue
       }
 

--- a/tooling/scripts/bin/squash.js
+++ b/tooling/scripts/bin/squash.js
@@ -50,9 +50,7 @@ const ensureCleanWorkingTree = async () => {
     await $`git diff --quiet`
     await $`git diff --cached --quiet`
   } catch {
-    throw new Error(
-      'Working tree must be clean (no staged or unstaged changes) before squashing.',
-    )
+    throw new Error('Working tree must be clean (no staged or unstaged changes) before squashing.')
   }
 }
 
@@ -60,9 +58,7 @@ const ensureDerivedFromBase = async (baseBranch) => {
   try {
     await $`git merge-base --is-ancestor ${baseBranch} HEAD`
   } catch {
-    throw new Error(
-      `Current branch is not derived from ${baseBranch}. Rebase/merge required.`,
-    )
+    throw new Error(`Current branch is not derived from ${baseBranch}. Rebase/merge required.`)
   }
 }
 
@@ -142,9 +138,7 @@ const main = async () => {
     return
   }
 
-  const lastSquash = [...commits]
-    .reverse()
-    .find((c) => c.body.includes(SQUASH_MARKER))
+  const lastSquash = [...commits].reverse().find((c) => c.body.includes(SQUASH_MARKER))
 
   let priorBullets = []
   let newBullets = []
@@ -174,8 +168,7 @@ const main = async () => {
   const message = buildMessage({ header: finalHeader, bullets: allBullets })
 
   // Always show a preview of what will happen
-  const previewRange =
-    lastSquash ? `${lastSquash.sha}..HEAD` : `${mergeBase}..HEAD`
+  const previewRange = lastSquash ? `${lastSquash.sha}..HEAD` : `${mergeBase}..HEAD`
   console.log('Preview of squash commit:')
   console.log('Range  :', previewRange)
   console.log('Header :', finalHeader)
@@ -195,9 +188,7 @@ const main = async () => {
       input: process.stdin,
       output: process.stdout,
     })
-    const answer = await new Promise((resolve) =>
-      rl.question('Proceed with squash? [y/N] ', resolve),
-    )
+    const answer = await new Promise((resolve) => rl.question('Proceed with squash? [y/N] ', resolve))
     rl.close()
     const input = String(answer).trim().toLowerCase()
     return input === 'y' || input === 'yes'

--- a/tooling/scripts/lib/build-helpers/builders/tsc.js
+++ b/tooling/scripts/lib/build-helpers/builders/tsc.js
@@ -42,9 +42,7 @@ export const watch = () => {
   }
 
   if (hasTypescriptCjs) {
-    watches.push(
-      bg$`tsc --watch --preserveWatchOutput --project tsconfig.cjs.json`,
-    )
+    watches.push(bg$`tsc --watch --preserveWatchOutput --project tsconfig.cjs.json`)
   }
 
   return Promise.all(watches)

--- a/tooling/scripts/lib/build-helpers/builders/tsdown.js
+++ b/tooling/scripts/lib/build-helpers/builders/tsdown.js
@@ -13,9 +13,7 @@ const bundlerConfigFiles = [
   'tsdown.config',
 ]
 
-const hasBundlerConfig = bundlerConfigFiles.some((f) =>
-  fs.existsSync(path.resolve(f)),
-)
+const hasBundlerConfig = bundlerConfigFiles.some((f) => fs.existsSync(path.resolve(f)))
 
 export const supports = () => {
   return Promise.resolve(hasBundlerConfig)

--- a/tooling/scripts/lib/util/shell.js
+++ b/tooling/scripts/lib/util/shell.js
@@ -3,12 +3,7 @@ import { execa, execaSync } from 'execa'
 // Tagged-template shell helper. Reconstructs the command and runs it via a
 // shell so callers can write: $`docker build -f ${dockerfile} ${context}`
 export const $ = (strings, ...values) => {
-  const command = strings
-    .reduce(
-      (acc, s, i) => acc + s + (i < values.length ? String(values[i]) : ''),
-      '',
-    )
-    .trim()
+  const command = strings.reduce((acc, s, i) => acc + s + (i < values.length ? String(values[i]) : ''), '').trim()
 
   try {
     // Use shell:true so the full command string is interpreted by the shell.
@@ -24,12 +19,7 @@ export const $ = (strings, ...values) => {
 
 // For long-running background processes (watch, servers, etc.)
 export const bg$ = (strings, ...values) => {
-  const command = strings
-    .reduce(
-      (acc, s, i) => acc + s + (i < values.length ? String(values[i]) : ''),
-      '',
-    )
-    .trim()
+  const command = strings.reduce((acc, s, i) => acc + s + (i < values.length ? String(values[i]) : ''), '').trim()
 
   console.log(`🔄 Starting: ${command}`)
 


### PR DESCRIPTION
This change incorporates the following commits:
- 7137c13: add storage apis for bots to use
- 9d36905: add '!stats' command handling and incorporated persistence into bot
- 95cae2c: add persistent stat rolling and replay of existing stats
- 3d8c7bf: update prettier line width
- 6c1b659: add bot support for input command handling
- f39e819: update stats rolling to be a chat command instead of message-based