### PR TITLE
add 'Mod' column to stat roll results table

### DIFF
--- a/.changeset/six-cougars-shave.md
+++ b/.changeset/six-cougars-shave.md
@@ -1,0 +1,5 @@
+---
+'@twin-digital/codex': patch
+---
+
+add 'Mod' column to stat roll results table

--- a/nodejs/apps/codex/src/game/core/ability-scores.ts
+++ b/nodejs/apps/codex/src/game/core/ability-scores.ts
@@ -1,0 +1,78 @@
+import { makeLookupTable, type LookupTable } from './lookup-table.js'
+
+export interface AbilityScore {
+  /**
+   * Short name of the ability
+   */
+  abbreviation: string
+
+  /**
+   * Full name of the ability
+   */
+  name: string
+}
+
+export const AbilityScores: AbilityScore[] = [
+  {
+    abbreviation: 'str',
+    name: 'strength',
+  },
+  {
+    abbreviation: 'int',
+    name: 'intelligence',
+  },
+  {
+    abbreviation: 'wis',
+    name: 'wisdom',
+  },
+  {
+    abbreviation: 'dex',
+    name: 'dexterity',
+  },
+  {
+    abbreviation: 'con',
+    name: 'constitution',
+  },
+  {
+    abbreviation: 'cha',
+    name: 'charisma',
+  },
+] as const satisfies AbilityScore[]
+
+export const AbilityModifiers: LookupTable<number> = makeLookupTable([
+  {
+    maximumValue: 3,
+    minimumValue: Number.MIN_SAFE_INTEGER,
+    data: -3,
+  },
+  {
+    maximumValue: 5,
+    minimumValue: 4,
+    data: -2,
+  },
+  {
+    maximumValue: 8,
+    minimumValue: 6,
+    data: -1,
+  },
+  {
+    maximumValue: 12,
+    minimumValue: 9,
+    data: 0,
+  },
+  {
+    maximumValue: 15,
+    minimumValue: 13,
+    data: 1,
+  },
+  {
+    maximumValue: 17,
+    minimumValue: 16,
+    data: 2,
+  },
+  {
+    maximumValue: Number.MAX_SAFE_INTEGER,
+    minimumValue: 18,
+    data: 3,
+  },
+])

--- a/nodejs/apps/codex/src/game/core/lookup-table.ts
+++ b/nodejs/apps/codex/src/game/core/lookup-table.ts
@@ -1,0 +1,40 @@
+export interface LookupTableEntry<T> {
+  /**
+   * Maximum value (inclusive) which matches this result.
+   */
+  maximumValue: number
+
+  /**
+   * Minimum value (inclusive) which matches this result.
+   */
+  minimumValue: number
+
+  /**
+   * The result data to use when the range matches
+   */
+  data: T
+}
+
+export interface LookupTable<T> {
+  /**
+   * Looks up the specified value in the table, and returns the corresponding entry. If multiple overlapping ranges
+   * match (probably a misconfiguration), then the first one added to the table will be returned. If no entries match
+   * this function returns null.
+   */
+  lookup(value: number): LookupTableEntry<T> | null
+}
+
+export const makeLookupTable = <T>(entries: LookupTableEntry<T>[]): LookupTable<T> => {
+  const invalidEntries = entries.filter(({ maximumValue, minimumValue }) => minimumValue > maximumValue)
+  if (invalidEntries.length > 0) {
+    throw new Error(
+      `Invalid lookup table. "minimumValue" must be <= "maximumValue". [${invalidEntries.length} invalid entries]`,
+    )
+  }
+
+  return {
+    lookup: (value) => {
+      return entries.find((entry) => value >= entry.minimumValue && value <= entry.maximumValue) ?? null
+    },
+  }
+}


### PR DESCRIPTION
This change incorporates the following commits:
- 40c39cd: add basic ability score rules
- 69dbd05: add 'Mod' column to stat roll results table