### PR TITLE
refbash: prune lights and encounter when decrementing time

### DIFF
--- a/.changeset/loud-paths-rule.md
+++ b/.changeset/loud-paths-rule.md
@@ -1,0 +1,5 @@
+---
+'@twin-digital/refbash': patch
+---
+
+prune lights and encounters from future turns if time is decremented

--- a/.changeset/tender-states-peel.md
+++ b/.changeset/tender-states-peel.md
@@ -1,0 +1,6 @@
+---
+'@twin-digital/dolmenwood': patch
+'@twin-digital/refbash': patch
+---
+
+prune lights and encounter when decrementing time

--- a/nodejs/dolmenwood/refbash/src/components/delve-screen/delve-screen.tsx
+++ b/nodejs/dolmenwood/refbash/src/components/delve-screen/delve-screen.tsx
@@ -138,6 +138,7 @@ export const DelveScreeen = observer(({ delve, rows }: DelveScreenProps) => {
           flexDirection='column'
         >
           <LightSourcesTable delve={delve} focused={focus === 'light-sources'} />
+          {/* <StyleGuide /> */}
         </Box>
 
         {/* Middle column (2/5) - turn track */}
@@ -151,8 +152,6 @@ export const DelveScreeen = observer(({ delve, rows }: DelveScreenProps) => {
           borderBottom={false}
           flexDirection='column'
         >
-          {/* <StyleGuide /> */}
-
           <LogPanel
             eventLog={delve.eventLog}
             flexDirection='column'


### PR DESCRIPTION
This change incorporates the following commits:
- de5c6da: refbash: prune lights and encounters from future turns if time is decremented
- 3c00744: chore: move where style guide is placed by default