### PR TITLE
bookify: make bookify and bookify-cli publishable

### DIFF
--- a/.changeset/tiny-candles-smash.md
+++ b/.changeset/tiny-candles-smash.md
@@ -1,0 +1,6 @@
+---
+'@twin-digital/bookify-cli': patch
+'@twin-digital/bookify': patch
+---
+
+make package publishable

--- a/nodejs/bookify/bookify-cli/package.json
+++ b/nodejs/bookify/bookify-cli/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@twin-digital/bookify-cli",
   "version": "0.1.0",
   "description": "CLI toolkit for interacting with the Bookify publishing engine.",

--- a/nodejs/bookify/bookify/package.json
+++ b/nodejs/bookify/bookify/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@twin-digital/bookify",
   "version": "0.0.1",
   "description": "Core logic and models for the Bookify platform",


### PR DESCRIPTION
This change incorporates the following commits:
- 8df48ec: bookify: make bookify and bookify-cli publishable