### PR TITLE
chore: correctly teardown preview instances

### DIFF
--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -32,12 +32,22 @@ jobs:
         id: slugify
         shell: bash
         run: |
-          RAW="${{ github.event.pull_request.head.ref }}"
+          # For PRs use `pr-<number>` as the stage; otherwise use 'preview'
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && \
+             [[ "${{ github.event.pull_request.base.ref }}" == "main" ]]; then
+            RAW="pr-${{ github.event.pull_request.number }}"
+          else
+            RAW="preview"
+          fi
+
+          # slugify (keeps only simple characters)
           SLUG=$(echo "$RAW" \
             | tr '[:upper:]' '[:lower:]' \
             | sed -E 's/[^a-z0-9_-]+/-/g' \
             | sed -E 's/^-+|-+$//g')
-          echo "STAGE=$SLUG" >> $GITHUB_OUTPUT
+
+          echo "Destroying stage: $SLUG"
+          echo "stage=$SLUG" >> $GITHUB_OUTPUT
 
       - name: Destroy preview
         uses: ./.github/actions/deploy


### PR DESCRIPTION
This change incorporates the following commits:
- 7e0cada: chore: correctly tear down preview instances