### PR TITLE
chore: turbo cache-correctness + performance fixes

### DIFF
--- a/.changeset/turbo-audit-fixes.md
+++ b/.changeset/turbo-audit-fixes.md
@@ -1,0 +1,8 @@
+---
+---
+
+chore: turbo task-graph cache-correctness and performance fixes (no package code changed)
+
+- Add `globalDependencies` for the shared base `tsconfig` files and root `.prettierrc`/`.prettierignore`, which affect `build`/`typecheck`/`lint` output but were not hashed — editing them previously served stale cached results.
+- Point `lint`, `lint:fix`, and `typecheck` at the `upstream-sources` transit node instead of `^build`. In the source-first setup these resolve dependencies from `src`, so they no longer trigger a full dependency-graph build (only the `eslint-config` toolchain that `lint` loads at runtime).
+- Raise `concurrency` 5 → 10, give `test` explicit `inputs`, and mark `lint:fix` `cache: false`.

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,13 @@
 {
   "$schema": "./node_modules/turbo/schema.json",
-  "concurrency": "5",
+  "concurrency": "10",
   "globalPassThroughEnv": ["CI"],
+  "globalDependencies": [
+    ".prettierrc",
+    ".prettierignore",
+    "nodejs/devtools/tsconfig/tsconfig.json",
+    "nodejs/devtools/tsconfig/tsconfig.build.json"
+  ],
   "tasks": {
     "artifact": {
       "dependsOn": ["build"],
@@ -26,17 +32,19 @@
       "passThroughEnv": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "SERVERLESS_ACCESS_KEY"]
     },
     "lint": {
-      "dependsOn": ["^build", "@twin-digital/eslint-config#build", "//#lint:deps"],
+      "dependsOn": ["upstream-sources", "@twin-digital/eslint-config#build", "//#lint:deps"],
       "inputs": ["eslint.config.js", "package.json", "src/**"]
     },
     "lint:fix": {
-      "dependsOn": ["^build", "@twin-digital/eslint-config#build"]
+      "cache": false,
+      "dependsOn": ["upstream-sources", "@twin-digital/eslint-config#build"]
     },
     "//#lint:deps": {
       "inputs": ["**/package.json", "pnpm-workspace.yaml"]
     },
     "test": {
       "dependsOn": ["upstream-sources", "@twin-digital/vitest-config#build"],
+      "inputs": ["src/**", "package.json", "vitest.config.ts", "tsconfig.json", "tsconfig.*.json"],
       "outputs": ["coverage.json"]
     },
     "test:watch": {
@@ -45,7 +53,7 @@
       "persistent": true
     },
     "typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["upstream-sources"],
       "inputs": ["package.json", "tsconfig.json", "tsconfig.*.json", "src/**"],
       "outputs": []
     },


### PR DESCRIPTION
Findings from a turbo config audit. No package code changes — `turbo.json` only.

## 1. Correctness: stale caches on shared-config changes (the real bug)

The shared base `tsconfig` files and root `.prettierrc`/`.prettierignore` affect `build`/`typecheck`/`lint` *output*, but nothing hashed them:
- `@twin-digital/tsconfig` has no `build` task, so `^build` traverses it as a transit node but contributes none of its files to dependents' hashes.
- root prettier config is a root file in no package's `inputs`, and turbo's global hash doesn't cover arbitrary root files.

**Verified empirically** (leaf `typecheck`/`lint`, stable double-run baseline):
| | edit base tsconfig → typecheck | edit `.prettierrc` → lint |
|---|---|---|
| before | **HIT (stale)** | **HIT (stale)** |
| after  | **MISS (rebuilds)** | **MISS (rebuilds)** |

Fix: declare them in `globalDependencies`.

## 2. Performance: `lint`/`typecheck` no longer build the whole graph

They depended on `^build`, but source-first resolution means they read deps' `src/`, not `dist/` — so `^build` only forced needless builds. Switched `lint`, `lint:fix`, and `typecheck` to the existing `upstream-sources` transit node (same pattern `test` already used). Cache correctness is preserved (the transit node propagates dep `src` hashes); `lint` keeps `@twin-digital/eslint-config#build` because it loads that config at runtime.

Result (`turbo run typecheck --filter=<leaf>` dry-run): **0** build tasks pulled in (was the package's whole dependency tree). `lint` pulls in only the small `eslint-config` toolchain.

## 4. Tuning

- `concurrency` 5 → 10
- `test` given explicit `inputs` (was defaulting to all package files → README edits busted tests)
- `lint:fix` marked `cache: false` (side-effecting fix task)

## Note on #3 (not included)

I measured switching `build` itself off `^build` onto the transit node for more parallelism. **Empirically it's a wash** — full forced cold build ~11.5s both ways at concurrency 10 — so it's intentionally left out. Detail in the PR thread / assessment.

## Verification
`build` 20/20 · `typecheck` 20/20 · `lint` 21/21 · `test` 10/10, plus the before/after staleness table above.