### PR TITLE
ci: add a 5-day Renovate cooldown (minimumReleaseAge)

### DIFF
--- a/.changeset/renovate-minimum-release-age.md
+++ b/.changeset/renovate-minimum-release-age.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: hold Renovate updates until releases are at least 5 days old (minimumReleaseAge + strict internalChecksFilter)

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
     "group:allNonMajor"
   ],
   "schedule": ["before 6am on monday"],
+  "minimumReleaseAge": "5 days",
+  "internalChecksFilter": "strict",
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "labels": ["dependencies"],


### PR DESCRIPTION
## What

Adds a release-age floor to `renovate.json` so dependency updates aren't pulled in the moment they publish:

```jsonc
"minimumReleaseAge": "5 days",
"internalChecksFilter": "strict",
```

- **`minimumReleaseAge: "5 days"`** — Renovate won't propose an update until the release is ≥5 days old, dodging versions that get yanked or hotfixed right after publish.
- **`internalChecksFilter: "strict"`** — filters too-new releases out of the candidate set entirely, instead of opening a PR that sits in a pending/blocked state.

## Notes

- **Security updates intentionally bypass this.** Vulnerability-driven PRs ignore `minimumReleaseAge` by design (you want those fast); no change to that behavior here.
- Independent of the signed-commits work (#108) and the automerge discussion — this is a standalone config tweak.
- Empty changeset included (config-only; no package `src/` touched).