### PR TITLE
fix(devcontainer): build credential-shelf image (uid 1000) + decouple docker from npm

### DIFF
--- a/.changeset/decouple-docker-from-npm-publish.md
+++ b/.changeset/decouple-docker-from-npm-publish.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(publish): build and push Docker images even when `npm publish` fails. The `docker-matrix`/`docker-status-check` jobs no longer require the `publish` job to fully succeed — image builds are gated on their own tag detection (`docker-packages.js` only emits packages tagged at HEAD), so an unrelated npm-publish failure no longer skips them.

--- a/.changeset/fix-devcontainer-image-builds.md
+++ b/.changeset/fix-devcontainer-image-builds.md
@@ -1,0 +1,6 @@
+---
+'@twin-digital/credential-shelf': patch
+'@twin-digital/workspace': patch
+---
+
+fix(credential-shelf): drop the base image's `node` user so `credential-vendor` can own uid/gid 1000. `node:24-bookworm-slim` ships a `node` user/group at 1000, so `groupadd -g 1000` collided (exit 4) and the image build failed. Also re-tags `workspace` to rebuild it after a transient `mcr.microsoft.com` base-pull failure (no image change).

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -118,7 +118,11 @@ jobs:
   # Prepare matrix of Docker packages to build
   docker-matrix:
     needs: publish
-    if: needs.publish.outputs.hasChangesets == 'false'
+    # Run on a release (publish succeeded, hasChangesets=false) AND when publish FAILED — an
+    # npm-publish failure of unrelated packages shouldn't block image builds, which are gated
+    # on their own tag detection below (docker-packages.js only emits packages tagged at HEAD).
+    # Skips the "create Version Packages PR" runs (publish success + hasChangesets=true).
+    if: ${{ !cancelled() && (needs.publish.result == 'failure' || needs.publish.outputs.hasChangesets == 'false') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -209,7 +213,7 @@ jobs:
   # Check Docker build status and fail workflow if any builds failed
   docker-status-check:
     needs: [publish, docker-matrix, docker-build-publish]
-    if: always() && needs.publish.outputs.hasChangesets == 'false' && needs.docker-matrix.outputs.has-packages == 'true'
+    if: always() && needs.docker-matrix.outputs.has-packages == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/nodejs/devcontainer/credential-shelf/Dockerfile
+++ b/nodejs/devcontainer/credential-shelf/Dockerfile
@@ -55,7 +55,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Unprivileged vendor account at uid/gid 1000 — that uid (not the name) is the contract: it
 # must match the consumer's uid so the 0600 shelf files are readable on the read-only mount.
-RUN groupadd -g 1000 credential-vendor \
+# node:24 ships a `node` user/group at 1000, so drop it first to free the uid/gid.
+RUN userdel -r node 2>/dev/null || true; groupdel node 2>/dev/null || true; \
+    groupadd -g 1000 credential-vendor \
   && useradd -m -u 1000 -g 1000 -s /bin/bash credential-vendor \
   && mkdir -p /creds && chown credential-vendor /creds
 

--- a/nodejs/devcontainer/credential-shelf/Dockerfile
+++ b/nodejs/devcontainer/credential-shelf/Dockerfile
@@ -55,10 +55,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Unprivileged vendor account at uid/gid 1000 — that uid (not the name) is the contract: it
 # must match the consumer's uid so the 0600 shelf files are readable on the read-only mount.
-# node:24 ships a `node` user/group at 1000, so drop it first to free the uid/gid.
-RUN userdel -r node 2>/dev/null || true; groupdel node 2>/dev/null || true; \
-    groupadd -g 1000 credential-vendor \
-  && useradd -m -u 1000 -g 1000 -s /bin/bash credential-vendor \
+# Drop ALL pre-made users at uid >= 1000 (node:24 ships `node` at 1000) so credential-vendor
+# can take 1000 — same approach as the workspace image.
+RUN getent passwd \
+    | awk -F: '($3 >= 1000) && ($1 != "nobody") {print $1}' \
+    | xargs -r -n 1 userdel -r \
+  && rm -rf /etc/sudoers.d/* \
+  && { groupadd --gid 1000 credential-vendor || true; } \
+  && useradd -s /bin/bash -m -u 1000 -g 1000 credential-vendor \
   && mkdir -p /creds && chown credential-vendor /creds
 
 # Baked default config (idle). Override in a derived image, NOT a /workspace bind-mount.


### PR DESCRIPTION
Follow-up to #178: fixes the two failures from the first image-build run and hardens the publish workflow.

## Fixes
- **`credential-shelf` build (real bug):** `node:24-bookworm-slim` ships a `node` user/group at uid/gid **1000**, so `groupadd -g 1000 credential-vendor` collided (exit 4) and the build failed. Drop the `node` user/group first, then create `credential-vendor` at 1000 (the shelf contract — consumers read the 0600 files as uid 1000).
- **`workspace` build (transient):** it 401'd pulling `mcr.microsoft.com/devcontainers/base:ubuntu` (Microsoft's registry), so the build never started. Re-tagged here to retry; if the 401 recurs it's infra (pin base by digest / pull retry / `docker login` to MCR).

## Hardening
- **Decouple docker builds from npm publish.** `docker-matrix`/`docker-status-check` now run even when the `publish` job fails, so an unrelated `npm publish` failure no longer skips image builds. Builds stay gated on their own tag detection (`docker-packages.js` only emits packages tagged at HEAD); `docker-build-publish` only needs `docker-matrix`, so it's unaffected. The "create Version Packages PR" runs are still skipped.

## Changesets
Patch `credential-shelf` (the fix) and `workspace` (re-tag → rebuild after the MCR blip); empty changeset for the workflow change. The re-tags are what make `docker-matrix` pick the images up on the next release.

## Note
The image builds couldn't be verified locally (no Docker in the dev env); the prior publish run is what surfaced these. This release cycle is the next verification.